### PR TITLE
chore: clean up jcenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,6 @@ buildscript {
     repositories {
         maven { url "https://plugins.gradle.org/m2/" }
         google()
-        jcenter()
         mavenCentral()
     }
 
@@ -29,7 +28,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 }
 


### PR DESCRIPTION
https://developer.android.com/studio/build/jcenter-migration

Remove jcenter as it is deprecated