### PR TITLE
fix: use in memory cache for variant access from storage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:4.0.1"
+        classpath "com.android.tools.build:gradle:4.0.2"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokka_version"
         classpath "io.github.gradle-nexus:publish-plugin:1.1.0"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.json:json:20201115'
+    testImplementation project(path: ':sdk')
 }
 
 task docs(dependsOn: dokkaHtml) {

--- a/sdk/src/main/java/com/amplitude/experiment/DefaultExperimentClient.kt
+++ b/sdk/src/main/java/com/amplitude/experiment/DefaultExperimentClient.kt
@@ -51,7 +51,6 @@ internal class DefaultExperimentClient internal constructor(
         scalar = 1.5f,
     )
 
-    private val storageLock = Any()
     private val serverUrl: HttpUrl = config.serverUrl.toHttpUrl()
 
     @Deprecated("moved to experiment config")
@@ -275,7 +274,7 @@ internal class DefaultExperimentClient internal constructor(
         return variants
     }
 
-    private fun storeVariants(variants: Map<String, Variant>, options: FetchOptions?) = synchronized(storageLock) {
+    private fun storeVariants(variants: Map<String, Variant>, options: FetchOptions?) = synchronized(storage) {
         val failedFlagKeys = options?.flagKeys ?.toMutableList() ?: mutableListOf()
         if (options?.flagKeys == null) {
             storage.clear()


### PR DESCRIPTION
* too much pressure was being applied to the shared preferences by lots of calls to `.variant()`
* lots of wasted effort serializing all variant payloads every time a variant was accessed.