### PR TITLE
fix: load from storage async in init

### DIFF
--- a/sdk/src/main/java/com/amplitude/experiment/DefaultExperimentClient.kt
+++ b/sdk/src/main/java/com/amplitude/experiment/DefaultExperimentClient.kt
@@ -4,7 +4,6 @@ import com.amplitude.experiment.evaluation.EvaluationEngineImpl
 import com.amplitude.experiment.evaluation.EvaluationFlag
 import com.amplitude.experiment.evaluation.json
 import com.amplitude.experiment.evaluation.topologicalSort
-import com.amplitude.experiment.storage.LoadStoreCache
 import com.amplitude.experiment.storage.Storage
 import com.amplitude.experiment.storage.getFlagStorage
 import com.amplitude.experiment.storage.getVariantStorage

--- a/sdk/src/main/java/com/amplitude/experiment/Experiment.kt
+++ b/sdk/src/main/java/com/amplitude/experiment/Experiment.kt
@@ -17,7 +17,7 @@ object Experiment {
                 isDaemon = true
             }
         }
-    internal val executorService = ScheduledThreadPoolExecutor(2, daemonThreadFactory)
+    internal val executorService = ScheduledThreadPoolExecutor(4, daemonThreadFactory)
 
     private val httpClient = OkHttpClient()
     private val instances = mutableMapOf<String, ExperimentClient>()

--- a/sdk/src/main/java/com/amplitude/experiment/storage/Cache.kt
+++ b/sdk/src/main/java/com/amplitude/experiment/storage/Cache.kt
@@ -16,15 +16,12 @@ internal class LoadStoreCache<V>(
     private val onLoad: (() -> Unit)? = null,
 ) {
     private val cache: MutableMap<String, V> = mutableMapOf()
-    private var isLoaded = false
 
     fun get(key: String): V? {
-        if (!isLoaded) load()
         return cache[key]
     }
 
     fun getAll(): Map<String, V> {
-        if (!isLoaded) load()
         return HashMap(cache)
     }
 
@@ -65,7 +62,6 @@ internal class LoadStoreCache<V>(
         clear()
         putAll(values)
         onLoad?.invoke()
-        isLoaded = true
     }
 
     fun store(values: MutableMap<String, V> = cache) {

--- a/sdk/src/main/java/com/amplitude/experiment/storage/Cache.kt
+++ b/sdk/src/main/java/com/amplitude/experiment/storage/Cache.kt
@@ -16,12 +16,15 @@ internal class LoadStoreCache<V>(
     private val onLoad: (() -> Unit)? = null,
 ) {
     private val cache: MutableMap<String, V> = mutableMapOf()
+    private var isLoaded = false
 
     fun get(key: String): V? {
+        if (!isLoaded) load()
         return cache[key]
     }
 
     fun getAll(): Map<String, V> {
+        if (!isLoaded) load()
         return HashMap(cache)
     }
 
@@ -62,6 +65,7 @@ internal class LoadStoreCache<V>(
         clear()
         putAll(values)
         onLoad?.invoke()
+        isLoaded = true
     }
 
     fun store(values: MutableMap<String, V> = cache) {

--- a/sdk/src/main/java/com/amplitude/experiment/storage/Cache.kt
+++ b/sdk/src/main/java/com/amplitude/experiment/storage/Cache.kt
@@ -64,8 +64,8 @@ internal class LoadStoreCache<V>(
             }.toMap()
         clear()
         putAll(values)
-        onLoad?.invoke()
         isLoaded = true
+        onLoad?.invoke()
     }
 
     fun store(values: MutableMap<String, V> = cache) {


### PR DESCRIPTION
Synchronized access around all storage operations in DefaultExperimentClient ensure load has completed before other access even though load is run on a background thread.