### PR TITLE
fix: SKY-32 pass current user to exposure tracker to reset dedup on identity change

### DIFF
--- a/sdk/src/main/java/com/amplitude/experiment/DefaultExperimentClient.kt
+++ b/sdk/src/main/java/com/amplitude/experiment/DefaultExperimentClient.kt
@@ -303,7 +303,7 @@ internal class DefaultExperimentClient internal constructor(
 
         val exposure = Exposure(key, variant, experimentKey, metadata)
 
-        userSessionExposureTracker?.track(exposure)
+        userSessionExposureTracker?.track(exposure, getUserMergedWithProvider())
     }
 
     private fun legacyExposureInternal(

--- a/sdk/src/test/java/com/amplitude/experiment/ExperimentClientTest.kt
+++ b/sdk/src/test/java/com/amplitude/experiment/ExperimentClientTest.kt
@@ -1646,4 +1646,44 @@ class ExperimentClientTest {
         val library = fetchLibraryFromRequest(mockHttp)
         Assert.assertEquals("custom-wrapper/1.0.0", library)
     }
+
+    @Test
+    fun `exposure dedup resets on user identity change - same flag same variant re-tracks for new user`() {
+        val provider = TestExposureTrackingProvider()
+        val flagKey = "test-flag"
+        val flagVariant = Variant(key = "on", value = "on")
+        val client =
+            DefaultExperimentClient(
+                API_KEY,
+                ExperimentConfig(
+                    exposureTrackingProvider = provider,
+                    fetchOnStart = false,
+                    source = Source.LOCAL_STORAGE,
+                    initialVariants = mapOf(flagKey to flagVariant),
+                ),
+                OkHttpClient(),
+                MockStorage(),
+                Experiment.executorService,
+            )
+
+        // User A sees flag -> variant "on"
+        client.setUser(ExperimentUser(userId = "user-a"))
+        client.variant(flagKey)
+        Assert.assertEquals(1, provider.trackCount)
+
+        // Repeat calls for User A are deduped
+        client.variant(flagKey)
+        client.variant(flagKey)
+        Assert.assertEquals(1, provider.trackCount)
+
+        // User B logs in on the same device/session with the same flag -> variant "on"
+        // Exposure must fire again because the identity changed
+        client.setUser(ExperimentUser(userId = "user-b"))
+        client.variant(flagKey)
+        Assert.assertEquals(2, provider.trackCount)
+
+        // Repeat calls for User B are deduped
+        client.variant(flagKey)
+        Assert.assertEquals(2, provider.trackCount)
+    }
 }

--- a/sdk/src/test/java/com/amplitude/experiment/ExperimentClientTest.kt
+++ b/sdk/src/test/java/com/amplitude/experiment/ExperimentClientTest.kt
@@ -1646,44 +1646,4 @@ class ExperimentClientTest {
         val library = fetchLibraryFromRequest(mockHttp)
         Assert.assertEquals("custom-wrapper/1.0.0", library)
     }
-
-    @Test
-    fun `exposure dedup resets on user identity change - same flag same variant re-tracks for new user`() {
-        val provider = TestExposureTrackingProvider()
-        val flagKey = "test-flag"
-        val flagVariant = Variant(key = "on", value = "on")
-        val client =
-            DefaultExperimentClient(
-                API_KEY,
-                ExperimentConfig(
-                    exposureTrackingProvider = provider,
-                    fetchOnStart = false,
-                    source = Source.LOCAL_STORAGE,
-                    initialVariants = mapOf(flagKey to flagVariant),
-                ),
-                OkHttpClient(),
-                MockStorage(),
-                Experiment.executorService,
-            )
-
-        // User A sees flag -> variant "on"
-        client.setUser(ExperimentUser(userId = "user-a"))
-        client.variant(flagKey)
-        Assert.assertEquals(1, provider.trackCount)
-
-        // Repeat calls for User A are deduped
-        client.variant(flagKey)
-        client.variant(flagKey)
-        Assert.assertEquals(1, provider.trackCount)
-
-        // User B logs in on the same device/session with the same flag -> variant "on"
-        // Exposure must fire again because the identity changed
-        client.setUser(ExperimentUser(userId = "user-b"))
-        client.variant(flagKey)
-        Assert.assertEquals(2, provider.trackCount)
-
-        // Repeat calls for User B are deduped
-        client.variant(flagKey)
-        Assert.assertEquals(2, provider.trackCount)
-    }
 }

--- a/sdk/src/test/java/com/amplitude/experiment/ExperimentClientTest.kt
+++ b/sdk/src/test/java/com/amplitude/experiment/ExperimentClientTest.kt
@@ -1646,4 +1646,90 @@ class ExperimentClientTest {
         val library = fetchLibraryFromRequest(mockHttp)
         Assert.assertEquals("custom-wrapper/1.0.0", library)
     }
+
+    @Test
+    fun `exposure dedup resets on user id change`() {
+        val provider = TestExposureTrackingProvider()
+        val flagKey = "test-flag"
+        val client =
+            DefaultExperimentClient(
+                API_KEY,
+                ExperimentConfig(
+                    exposureTrackingProvider = provider,
+                    fetchOnStart = false,
+                    source = Source.LOCAL_STORAGE,
+                    initialVariants = mapOf(flagKey to Variant(key = "on", value = "on")),
+                ),
+                OkHttpClient(),
+                MockStorage(),
+                Experiment.executorService,
+            )
+
+        client.setUser(ExperimentUser(userId = "user-a"))
+        client.variant(flagKey)
+        Assert.assertEquals(1, provider.trackCount)
+
+        // repeated calls for same user are deduped
+        client.variant(flagKey)
+        Assert.assertEquals(1, provider.trackCount)
+
+        // new user — cache must reset and exposure must fire again
+        client.setUser(ExperimentUser(userId = "user-b"))
+        client.variant(flagKey)
+        Assert.assertEquals(2, provider.trackCount)
+
+        // repeated calls for new user are deduped
+        client.variant(flagKey)
+        Assert.assertEquals(2, provider.trackCount)
+    }
+
+    @Test
+    fun `exposure dedup resets on device id change`() {
+        val provider = TestExposureTrackingProvider()
+        val flagKey = "test-flag"
+        val client =
+            DefaultExperimentClient(
+                API_KEY,
+                ExperimentConfig(
+                    exposureTrackingProvider = provider,
+                    fetchOnStart = false,
+                    source = Source.LOCAL_STORAGE,
+                    initialVariants = mapOf(flagKey to Variant(key = "on", value = "on")),
+                ),
+                OkHttpClient(),
+                MockStorage(),
+                Experiment.executorService,
+            )
+
+        client.setUser(ExperimentUser(deviceId = "device-a"))
+        client.variant(flagKey)
+        Assert.assertEquals(1, provider.trackCount)
+
+        client.setUser(ExperimentUser(deviceId = "device-b"))
+        client.variant(flagKey)
+        Assert.assertEquals(2, provider.trackCount)
+    }
+
+    @Test
+    fun `exposure dedup does not reset when user identity is unchanged`() {
+        val provider = TestExposureTrackingProvider()
+        val flagKey = "test-flag"
+        val client =
+            DefaultExperimentClient(
+                API_KEY,
+                ExperimentConfig(
+                    exposureTrackingProvider = provider,
+                    fetchOnStart = false,
+                    source = Source.LOCAL_STORAGE,
+                    initialVariants = mapOf(flagKey to Variant(key = "on", value = "on")),
+                ),
+                OkHttpClient(),
+                MockStorage(),
+                Experiment.executorService,
+            )
+
+        client.setUser(ExperimentUser(userId = "user-a"))
+        repeat(5) { client.variant(flagKey) }
+        Assert.assertEquals(1, provider.trackCount)
+    }
 }

--- a/sdk/src/test/java/com/amplitude/experiment/ExperimentClientTest.kt
+++ b/sdk/src/test/java/com/amplitude/experiment/ExperimentClientTest.kt
@@ -1657,7 +1657,7 @@ class ExperimentClientTest {
                 ExperimentConfig(
                     exposureTrackingProvider = provider,
                     fetchOnStart = false,
-                    source = Source.LOCAL_STORAGE,
+                    source = Source.INITIAL_VARIANTS,
                     initialVariants = mapOf(flagKey to Variant(key = "on", value = "on")),
                 ),
                 OkHttpClient(),
@@ -1693,7 +1693,7 @@ class ExperimentClientTest {
                 ExperimentConfig(
                     exposureTrackingProvider = provider,
                     fetchOnStart = false,
-                    source = Source.LOCAL_STORAGE,
+                    source = Source.INITIAL_VARIANTS,
                     initialVariants = mapOf(flagKey to Variant(key = "on", value = "on")),
                 ),
                 OkHttpClient(),
@@ -1720,7 +1720,7 @@ class ExperimentClientTest {
                 ExperimentConfig(
                     exposureTrackingProvider = provider,
                     fetchOnStart = false,
-                    source = Source.LOCAL_STORAGE,
+                    source = Source.INITIAL_VARIANTS,
                     initialVariants = mapOf(flagKey to Variant(key = "on", value = "on")),
                 ),
                 OkHttpClient(),

--- a/sdk/src/test/java/com/amplitude/experiment/ExperimentClientTest.kt
+++ b/sdk/src/test/java/com/amplitude/experiment/ExperimentClientTest.kt
@@ -1732,4 +1732,60 @@ class ExperimentClientTest {
         repeat(5) { client.variant(flagKey) }
         Assert.assertEquals(1, provider.trackCount)
     }
+
+    @Test
+    fun `exposure dedup resets on user id and device id change`() {
+        val provider = TestExposureTrackingProvider()
+        val flagKey = "test-flag"
+        val client =
+            DefaultExperimentClient(
+                API_KEY,
+                ExperimentConfig(
+                    exposureTrackingProvider = provider,
+                    fetchOnStart = false,
+                    source = Source.INITIAL_VARIANTS,
+                    initialVariants = mapOf(flagKey to Variant(key = "on", value = "on")),
+                ),
+                OkHttpClient(),
+                MockStorage(),
+                Experiment.executorService,
+            )
+
+        client.setUser(ExperimentUser(userId = "user-a", deviceId = "device-a"))
+        client.variant(flagKey)
+        Assert.assertEquals(1, provider.trackCount)
+
+        client.setUser(ExperimentUser(userId = "user-b", deviceId = "device-b"))
+        client.variant(flagKey)
+        Assert.assertEquals(2, provider.trackCount)
+    }
+
+    @Test
+    fun `exposure dedup resets on anonymous to identified transition`() {
+        val provider = TestExposureTrackingProvider()
+        val flagKey = "test-flag"
+        val client =
+            DefaultExperimentClient(
+                API_KEY,
+                ExperimentConfig(
+                    exposureTrackingProvider = provider,
+                    fetchOnStart = false,
+                    source = Source.INITIAL_VARIANTS,
+                    initialVariants = mapOf(flagKey to Variant(key = "on", value = "on")),
+                ),
+                OkHttpClient(),
+                MockStorage(),
+                Experiment.executorService,
+            )
+
+        // anonymous user — device id only, no user id yet
+        client.setUser(ExperimentUser(deviceId = "device-a"))
+        client.variant(flagKey)
+        Assert.assertEquals(1, provider.trackCount)
+
+        // user signs up and gains a userId — identity changed, exposure must re-fire
+        client.setUser(ExperimentUser(userId = "user-b", deviceId = "device-a"))
+        client.variant(flagKey)
+        Assert.assertEquals(2, provider.trackCount)
+    }
 }


### PR DESCRIPTION
## Summary
Updated the exposure tracking call to include the merged user object, ensuring that the user session exposure tracker receives complete user information including provider-supplied data.

## Key Changes
- Modified `userSessionExposureTracker?.track()` call to pass both the exposure object and the merged user (obtained via `getUserMergedWithProvider()`)
- This ensures the exposure tracker has access to the complete user context when recording exposures

## Implementation Details
The change passes the result of `getUserMergedWithProvider()` as an additional parameter to the track method, allowing the exposure tracker to utilize both the base user data and any provider-supplied user information when processing exposure events.

https://claude.ai/code/session_01L4L8gXHR9xxzr4uCyJcT7D

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes exposure tracking semantics by keying deduplication to the merged `userId`/`deviceId`, which could increase exposure event volume if identity changes are frequent. Otherwise the change is localized to exposure tracking and covered by new tests.
> 
> **Overview**
> **Fixes exposure deduplication across identity changes.** `DefaultExperimentClient` now passes `getUserMergedWithProvider()` into `UserSessionExposureTracker.track(...)` so the tracker can detect `userId`/`deviceId` changes (including provider-supplied identity) and clear its per-session dedup cache.
> 
> Adds targeted tests asserting dedup *resets* on `userId`/`deviceId` changes and anonymous-to-identified transitions, and *does not* reset when identity is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2381a449dbb13b9c1238ecd98ddb6da34c265112. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->