### PR TITLE
fix: add TTL-based eviction to exposure dedup cache (SKY-33)

### DIFF
--- a/sdk/src/main/java/com/amplitude/experiment/DefaultExperimentClient.kt
+++ b/sdk/src/main/java/com/amplitude/experiment/DefaultExperimentClient.kt
@@ -153,7 +153,7 @@ internal class DefaultExperimentClient internal constructor(
         }
     private val userSessionExposureTracker: UserSessionExposureTracker? =
         config.exposureTrackingProvider?.let {
-            UserSessionExposureTracker(it)
+            UserSessionExposureTracker(it, config.exposureDedupCacheTtlMillis)
         }
 
     private val isRunningLock = Any()

--- a/sdk/src/main/java/com/amplitude/experiment/DefaultExperimentClient.kt
+++ b/sdk/src/main/java/com/amplitude/experiment/DefaultExperimentClient.kt
@@ -303,7 +303,7 @@ internal class DefaultExperimentClient internal constructor(
 
         val exposure = Exposure(key, variant, experimentKey, metadata)
 
-        userSessionExposureTracker?.track(exposure)
+        userSessionExposureTracker?.track(exposure, getUserMergedWithProvider())
     }
 
     private fun legacyExposureInternal(

--- a/sdk/src/main/java/com/amplitude/experiment/ExperimentConfig.kt
+++ b/sdk/src/main/java/com/amplitude/experiment/ExperimentConfig.kt
@@ -66,6 +66,8 @@ class ExperimentConfig internal constructor(
     @JvmField
     val exposureTrackingProvider: ExposureTrackingProvider? = Defaults.EXPOSURE_TRACKING_PROVIDER,
     @JvmField
+    val exposureDedupCacheTtlMillis: Long = Defaults.EXPOSURE_DEDUP_CACHE_TTL_MILLIS,
+    @JvmField
     val customRequestHeaders: (() -> Map<String, String>)? = Defaults.CUSTOM_REQUEST_HEADERS,
 ) {
     /**
@@ -184,6 +186,11 @@ class ExperimentConfig internal constructor(
         val EXPOSURE_TRACKING_PROVIDER: ExposureTrackingProvider? = null
 
         /**
+         * 1800000 (30 minutes). Set to Long.MAX_VALUE to disable TTL.
+         */
+        const val EXPOSURE_DEDUP_CACHE_TTL_MILLIS = 1_800_000L
+
+        /**
          * null
          */
         val CUSTOM_REQUEST_HEADERS: (() -> Map<String, String>)? = null
@@ -216,6 +223,7 @@ class ExperimentConfig internal constructor(
         private var userProvider = Defaults.USER_PROVIDER
         private var analyticsProvider = Defaults.ANALYTICS_PROVIDER
         private var exposureTrackingProvider = Defaults.EXPOSURE_TRACKING_PROVIDER
+        private var exposureDedupCacheTtlMillis = Defaults.EXPOSURE_DEDUP_CACHE_TTL_MILLIS
         private var customRequestHeaders = Defaults.CUSTOM_REQUEST_HEADERS
 
         fun debug(debug: Boolean) =
@@ -332,6 +340,11 @@ class ExperimentConfig internal constructor(
                 this.exposureTrackingProvider = exposureTrackingProvider
             }
 
+        fun exposureDedupCacheTtlMillis(exposureDedupCacheTtlMillis: Long) =
+            apply {
+                this.exposureDedupCacheTtlMillis = exposureDedupCacheTtlMillis
+            }
+
         fun customRequestHeaders(customRequestHeaders: (() -> Map<String, String>)?) =
             apply {
                 this.customRequestHeaders = customRequestHeaders
@@ -360,6 +373,7 @@ class ExperimentConfig internal constructor(
                 userProvider = userProvider,
                 analyticsProvider = analyticsProvider,
                 exposureTrackingProvider = exposureTrackingProvider,
+                exposureDedupCacheTtlMillis = exposureDedupCacheTtlMillis,
                 customRequestHeaders = customRequestHeaders,
             )
     }
@@ -387,5 +401,6 @@ class ExperimentConfig internal constructor(
             .userProvider(userProvider)
             .analyticsProvider(analyticsProvider)
             .exposureTrackingProvider(exposureTrackingProvider)
+            .exposureDedupCacheTtlMillis(exposureDedupCacheTtlMillis)
             .customRequestHeaders(customRequestHeaders)
 }

--- a/sdk/src/main/java/com/amplitude/experiment/util/UserSessionExposureTracker.kt
+++ b/sdk/src/main/java/com/amplitude/experiment/util/UserSessionExposureTracker.kt
@@ -7,9 +7,11 @@ import com.amplitude.experiment.ExposureTrackingProvider
 
 internal class UserSessionExposureTracker(
     private val trackingProvider: ExposureTrackingProvider,
+    private val ttlMillis: Long,
+    private val clock: () -> Long = { System.currentTimeMillis() },
 ) {
     private val lock = Any()
-    private val tracked = mutableSetOf<Exposure>()
+    private val tracked = mutableMapOf<Exposure, Long>()
     private var identity = Identity()
 
     fun track(
@@ -17,16 +19,17 @@ internal class UserSessionExposureTracker(
         user: ExperimentUser? = null,
     ) {
         synchronized(lock) {
+            val now = clock()
             val newIdentity = user.toIdentity()
             if (!identity.identityEquals(newIdentity)) {
                 tracked.clear()
             }
             identity = newIdentity
-            if (tracked.contains(exposure)) {
+            tracked.entries.removeAll { now - it.value > ttlMillis }
+            if (tracked.containsKey(exposure)) {
                 return@track
-            } else {
-                tracked.add(exposure)
             }
+            tracked[exposure] = now
         }
         trackingProvider.track(exposure)
     }

--- a/sdk/src/test/java/com/amplitude/experiment/ExperimentClientTest.kt
+++ b/sdk/src/test/java/com/amplitude/experiment/ExperimentClientTest.kt
@@ -1646,4 +1646,44 @@ class ExperimentClientTest {
         val library = fetchLibraryFromRequest(mockHttp)
         Assert.assertEquals("custom-wrapper/1.0.0", library)
     }
+
+    @Test
+    fun `exposure dedup resets on user identity change - same flag same variant re-tracks for new user`() {
+        val provider = TestExposureTrackingProvider()
+        val flagKey = "test-flag"
+        val flagVariant = Variant(key = "on", value = "on")
+        val client =
+            DefaultExperimentClient(
+                API_KEY,
+                ExperimentConfig(
+                    exposureTrackingProvider = provider,
+                    fetchOnStart = false,
+                    source = Source.LOCAL_STORAGE,
+                    initialVariants = mapOf(flagKey to flagVariant),
+                ),
+                OkHttpClient(),
+                MockStorage(),
+                Experiment.executorService,
+            )
+
+        // User A sees flag -> variant "on"
+        client.setUser(ExperimentUser(userId = "user-a"))
+        client.variant(flagKey)
+        Assert.assertEquals(1, provider.trackCount)
+
+        // Repeat calls for User A are deduped
+        client.variant(flagKey)
+        client.variant(flagKey)
+        Assert.assertEquals(1, provider.trackCount)
+
+        // User B logs in on the same device/session with the same flag -> variant "on"
+        // Exposure must fire again because the identity changed
+        client.setUser(ExperimentUser(userId = "user-b"))
+        client.variant(flagKey)
+        Assert.assertEquals(2, provider.trackCount)
+
+        // Repeat calls for User B are deduped
+        client.variant(flagKey)
+        Assert.assertEquals(2, provider.trackCount)
+    }
 }

--- a/sdk/src/test/java/com/amplitude/experiment/ExperimentClientTest.kt
+++ b/sdk/src/test/java/com/amplitude/experiment/ExperimentClientTest.kt
@@ -1646,44 +1646,4 @@ class ExperimentClientTest {
         val library = fetchLibraryFromRequest(mockHttp)
         Assert.assertEquals("custom-wrapper/1.0.0", library)
     }
-
-    @Test
-    fun `exposure dedup resets on user identity change - same flag same variant re-tracks for new user`() {
-        val provider = TestExposureTrackingProvider()
-        val flagKey = "test-flag"
-        val flagVariant = Variant(key = "on", value = "on")
-        val client =
-            DefaultExperimentClient(
-                API_KEY,
-                ExperimentConfig(
-                    exposureTrackingProvider = provider,
-                    fetchOnStart = false,
-                    source = Source.LOCAL_STORAGE,
-                    initialVariants = mapOf(flagKey to flagVariant),
-                ),
-                OkHttpClient(),
-                MockStorage(),
-                Experiment.executorService,
-            )
-
-        // User A sees flag -> variant "on"
-        client.setUser(ExperimentUser(userId = "user-a"))
-        client.variant(flagKey)
-        Assert.assertEquals(1, provider.trackCount)
-
-        // Repeat calls for User A are deduped
-        client.variant(flagKey)
-        client.variant(flagKey)
-        Assert.assertEquals(1, provider.trackCount)
-
-        // User B logs in on the same device/session with the same flag -> variant "on"
-        // Exposure must fire again because the identity changed
-        client.setUser(ExperimentUser(userId = "user-b"))
-        client.variant(flagKey)
-        Assert.assertEquals(2, provider.trackCount)
-
-        // Repeat calls for User B are deduped
-        client.variant(flagKey)
-        Assert.assertEquals(2, provider.trackCount)
-    }
 }

--- a/sdk/src/test/java/com/amplitude/experiment/ExperimentClientTest.kt
+++ b/sdk/src/test/java/com/amplitude/experiment/ExperimentClientTest.kt
@@ -1646,4 +1646,90 @@ class ExperimentClientTest {
         val library = fetchLibraryFromRequest(mockHttp)
         Assert.assertEquals("custom-wrapper/1.0.0", library)
     }
+
+    @Test
+    fun `exposure dedup resets on user id change`() {
+        val provider = TestExposureTrackingProvider()
+        val flagKey = "test-flag"
+        val client =
+            DefaultExperimentClient(
+                API_KEY,
+                ExperimentConfig(
+                    exposureTrackingProvider = provider,
+                    fetchOnStart = false,
+                    source = Source.LOCAL_STORAGE,
+                    initialVariants = mapOf(flagKey to Variant(key = "on", value = "on")),
+                ),
+                OkHttpClient(),
+                MockStorage(),
+                Experiment.executorService,
+            )
+
+        client.setUser(ExperimentUser(userId = "user-a"))
+        client.variant(flagKey)
+        Assert.assertEquals(1, provider.trackCount)
+
+        // repeated calls for same user are deduped
+        client.variant(flagKey)
+        Assert.assertEquals(1, provider.trackCount)
+
+        // new user — cache must reset and exposure must fire again
+        client.setUser(ExperimentUser(userId = "user-b"))
+        client.variant(flagKey)
+        Assert.assertEquals(2, provider.trackCount)
+
+        // repeated calls for new user are deduped
+        client.variant(flagKey)
+        Assert.assertEquals(2, provider.trackCount)
+    }
+
+    @Test
+    fun `exposure dedup resets on device id change`() {
+        val provider = TestExposureTrackingProvider()
+        val flagKey = "test-flag"
+        val client =
+            DefaultExperimentClient(
+                API_KEY,
+                ExperimentConfig(
+                    exposureTrackingProvider = provider,
+                    fetchOnStart = false,
+                    source = Source.LOCAL_STORAGE,
+                    initialVariants = mapOf(flagKey to Variant(key = "on", value = "on")),
+                ),
+                OkHttpClient(),
+                MockStorage(),
+                Experiment.executorService,
+            )
+
+        client.setUser(ExperimentUser(deviceId = "device-a"))
+        client.variant(flagKey)
+        Assert.assertEquals(1, provider.trackCount)
+
+        client.setUser(ExperimentUser(deviceId = "device-b"))
+        client.variant(flagKey)
+        Assert.assertEquals(2, provider.trackCount)
+    }
+
+    @Test
+    fun `exposure dedup does not reset when user identity is unchanged`() {
+        val provider = TestExposureTrackingProvider()
+        val flagKey = "test-flag"
+        val client =
+            DefaultExperimentClient(
+                API_KEY,
+                ExperimentConfig(
+                    exposureTrackingProvider = provider,
+                    fetchOnStart = false,
+                    source = Source.LOCAL_STORAGE,
+                    initialVariants = mapOf(flagKey to Variant(key = "on", value = "on")),
+                ),
+                OkHttpClient(),
+                MockStorage(),
+                Experiment.executorService,
+            )
+
+        client.setUser(ExperimentUser(userId = "user-a"))
+        repeat(5) { client.variant(flagKey) }
+        Assert.assertEquals(1, provider.trackCount)
+    }
 }

--- a/sdk/src/test/java/com/amplitude/experiment/ExperimentClientTest.kt
+++ b/sdk/src/test/java/com/amplitude/experiment/ExperimentClientTest.kt
@@ -1657,7 +1657,7 @@ class ExperimentClientTest {
                 ExperimentConfig(
                     exposureTrackingProvider = provider,
                     fetchOnStart = false,
-                    source = Source.LOCAL_STORAGE,
+                    source = Source.INITIAL_VARIANTS,
                     initialVariants = mapOf(flagKey to Variant(key = "on", value = "on")),
                 ),
                 OkHttpClient(),
@@ -1693,7 +1693,7 @@ class ExperimentClientTest {
                 ExperimentConfig(
                     exposureTrackingProvider = provider,
                     fetchOnStart = false,
-                    source = Source.LOCAL_STORAGE,
+                    source = Source.INITIAL_VARIANTS,
                     initialVariants = mapOf(flagKey to Variant(key = "on", value = "on")),
                 ),
                 OkHttpClient(),
@@ -1720,7 +1720,7 @@ class ExperimentClientTest {
                 ExperimentConfig(
                     exposureTrackingProvider = provider,
                     fetchOnStart = false,
-                    source = Source.LOCAL_STORAGE,
+                    source = Source.INITIAL_VARIANTS,
                     initialVariants = mapOf(flagKey to Variant(key = "on", value = "on")),
                 ),
                 OkHttpClient(),

--- a/sdk/src/test/java/com/amplitude/experiment/ExperimentClientTest.kt
+++ b/sdk/src/test/java/com/amplitude/experiment/ExperimentClientTest.kt
@@ -1732,4 +1732,60 @@ class ExperimentClientTest {
         repeat(5) { client.variant(flagKey) }
         Assert.assertEquals(1, provider.trackCount)
     }
+
+    @Test
+    fun `exposure dedup resets on user id and device id change`() {
+        val provider = TestExposureTrackingProvider()
+        val flagKey = "test-flag"
+        val client =
+            DefaultExperimentClient(
+                API_KEY,
+                ExperimentConfig(
+                    exposureTrackingProvider = provider,
+                    fetchOnStart = false,
+                    source = Source.INITIAL_VARIANTS,
+                    initialVariants = mapOf(flagKey to Variant(key = "on", value = "on")),
+                ),
+                OkHttpClient(),
+                MockStorage(),
+                Experiment.executorService,
+            )
+
+        client.setUser(ExperimentUser(userId = "user-a", deviceId = "device-a"))
+        client.variant(flagKey)
+        Assert.assertEquals(1, provider.trackCount)
+
+        client.setUser(ExperimentUser(userId = "user-b", deviceId = "device-b"))
+        client.variant(flagKey)
+        Assert.assertEquals(2, provider.trackCount)
+    }
+
+    @Test
+    fun `exposure dedup resets on anonymous to identified transition`() {
+        val provider = TestExposureTrackingProvider()
+        val flagKey = "test-flag"
+        val client =
+            DefaultExperimentClient(
+                API_KEY,
+                ExperimentConfig(
+                    exposureTrackingProvider = provider,
+                    fetchOnStart = false,
+                    source = Source.INITIAL_VARIANTS,
+                    initialVariants = mapOf(flagKey to Variant(key = "on", value = "on")),
+                ),
+                OkHttpClient(),
+                MockStorage(),
+                Experiment.executorService,
+            )
+
+        // anonymous user — device id only, no user id yet
+        client.setUser(ExperimentUser(deviceId = "device-a"))
+        client.variant(flagKey)
+        Assert.assertEquals(1, provider.trackCount)
+
+        // user signs up and gains a userId — identity changed, exposure must re-fire
+        client.setUser(ExperimentUser(userId = "user-b", deviceId = "device-a"))
+        client.variant(flagKey)
+        Assert.assertEquals(2, provider.trackCount)
+    }
 }

--- a/sdk/src/test/java/com/amplitude/experiment/ExperimentClientTest.kt
+++ b/sdk/src/test/java/com/amplitude/experiment/ExperimentClientTest.kt
@@ -1788,4 +1788,61 @@ class ExperimentClientTest {
         client.variant(flagKey)
         Assert.assertEquals(2, provider.trackCount)
     }
+
+    @Test
+    fun `exposure dedup resets after TTL expires`() {
+        val provider = TestExposureTrackingProvider()
+        val flagKey = "test-flag"
+        val client =
+            DefaultExperimentClient(
+                API_KEY,
+                ExperimentConfig(
+                    exposureTrackingProvider = provider,
+                    fetchOnStart = false,
+                    source = Source.INITIAL_VARIANTS,
+                    initialVariants = mapOf(flagKey to Variant(key = "on", value = "on")),
+                    exposureDedupCacheTtlMillis = 1L,
+                ),
+                OkHttpClient(),
+                MockStorage(),
+                Experiment.executorService,
+            )
+
+        client.setUser(ExperimentUser(userId = "user-a"))
+        client.variant(flagKey)
+        Assert.assertEquals(1, provider.trackCount)
+
+        // still deduped before TTL expires
+        client.variant(flagKey)
+        Assert.assertEquals(1, provider.trackCount)
+
+        // wait for TTL to expire, then exposure must fire again
+        Thread.sleep(10)
+        client.variant(flagKey)
+        Assert.assertEquals(2, provider.trackCount)
+    }
+
+    @Test
+    fun `exposure dedup does not reset before TTL expires`() {
+        val provider = TestExposureTrackingProvider()
+        val flagKey = "test-flag"
+        val client =
+            DefaultExperimentClient(
+                API_KEY,
+                ExperimentConfig(
+                    exposureTrackingProvider = provider,
+                    fetchOnStart = false,
+                    source = Source.INITIAL_VARIANTS,
+                    initialVariants = mapOf(flagKey to Variant(key = "on", value = "on")),
+                    exposureDedupCacheTtlMillis = ExperimentConfig.Defaults.EXPOSURE_DEDUP_CACHE_TTL_MILLIS,
+                ),
+                OkHttpClient(),
+                MockStorage(),
+                Experiment.executorService,
+            )
+
+        client.setUser(ExperimentUser(userId = "user-a"))
+        repeat(5) { client.variant(flagKey) }
+        Assert.assertEquals(1, provider.trackCount)
+    }
 }


### PR DESCRIPTION
## Summary

Follow-up to #77 (SKY-32). SKY-32 fixed the dedup cache not resetting on identity change. This PR fixes the complementary issue: the cache had no time bound, so a returning logged-in user in a long-lived process would never re-fire exposures across app sessions.

- `UserSessionExposureTracker.tracked` is now a `Map<Exposure, Long>` (exposure → timestamp). Entries older than `ttlMillis` are evicted before each dedup check — no background timer needed.
- Default TTL is **30 minutes** (`ExperimentConfig.Defaults.EXPOSURE_DEDUP_CACHE_TTL_MILLIS`), configurable via `exposureDedupCacheTtlMillis` in `ExperimentConfig`. Set to `Long.MAX_VALUE` to restore the old no-expiry behavior.
- Identity-change reset from SKY-32 is preserved and regression-tested.

## Cross-platform scope

| SDK | This fix | Notes |
|-----|----------|-------|
| Android | ✅ This PR | |
| iOS | Separate PR needed | Same fix in Swift |
| Flutter | ✅ Free | No Dart-layer dedup; delegates to native |
| React Native | Separate PR needed | Own JS-layer `UserSessionExposureTracker`; different data structure |
| JavaScript/Web | Not needed | Browser lifecycle (sessionStorage + page reload) provides natural reset |
| Server-side | Not needed | Stateless per-request; no automatic exposure tracking |

## Test plan

- `exposure dedup resets after TTL expires` — 1ms TTL, fires exposure, deduped immediately after, waits 10ms, fires again → trackCount increments
- `exposure dedup does not reset before TTL expires` — default TTL, 5 repeated calls → trackCount stays at 1
- All SKY-32 identity-change tests still pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01L4L8gXHR9xxzr4uCyJcT7D)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes exposure deduplication behavior by expiring cached exposures over time and on identity changes, which can affect event volume and downstream analytics expectations.
> 
> **Overview**
> **Adds TTL-based eviction for exposure deduplication** so exposures can re-fire in long-lived processes after a configurable time window.
> 
> `UserSessionExposureTracker` now timestamps tracked exposures and evicts entries older than `ttlMillis` on each `track()` call, while still clearing the cache on user identity changes; `DefaultExperimentClient` now passes the merged user into `track()` for identity comparison.
> 
> Introduces `ExperimentConfig.exposureDedupCacheTtlMillis` (default **30 minutes**, `Long.MAX_VALUE` to effectively disable TTL) and adds regression tests covering identity-change resets and TTL expiry/non-expiry behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afbfbf905b98019619612f8fcb05888b6d46a3d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->