### PR TITLE
feat: add AmplitudeExperimentPlugin on UniversalPlugin

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -59,7 +59,7 @@ mavenPublishing {
 }
 
 dependencies {
-    api 'com.amplitude:analytics-core:1.30.0'
+    api 'com.amplitude:analytics-core:1.30.1'
     implementation 'com.amplitude:analytics-connector:1.0.0'
     implementation 'com.squareup.okhttp3:okhttp:4.9.1'
     implementation 'com.amplitude:android-sdk:2.26.1'

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -40,6 +40,8 @@ android {
     }
     kotlinOptions {
         jvmTarget = '1.8'
+        // Match analytics-core so UniversalPlugin default methods dispatch on ART.
+        freeCompilerArgs += ['-Xjvm-default=all']
     }
     namespace 'com.amplitude.experiment'
 }
@@ -55,7 +57,9 @@ mavenPublishing {
     configure(new AndroidSingleVariantLibrary("release", false, true))
 
     publishToMavenCentral()
-    signAllPublications()
+    if (findProperty("release.signing.enabled") != "false") {
+        signAllPublications()
+    }
 }
 
 dependencies {

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -59,6 +59,7 @@ mavenPublishing {
 }
 
 dependencies {
+    api 'com.amplitude:analytics-core:1.30.0'
     implementation 'com.amplitude:analytics-connector:1.0.0'
     implementation 'com.squareup.okhttp3:okhttp:4.9.1'
     implementation 'com.amplitude:android-sdk:2.26.1'

--- a/sdk/src/main/java/com/amplitude/experiment/AmplitudeExperimentPlugin.kt
+++ b/sdk/src/main/java/com/amplitude/experiment/AmplitudeExperimentPlugin.kt
@@ -9,7 +9,6 @@ import com.amplitude.core.AnalyticsClient
 import com.amplitude.core.AnalyticsIdentity
 import com.amplitude.core.events.AnalyticsEvent
 import com.amplitude.core.platform.UniversalPlugin
-import com.amplitude.experiment.storage.SharedPrefsStorage
 import com.amplitude.experiment.util.AmpLogger
 import com.amplitude.core.ServerZone as CoreServerZone
 
@@ -187,14 +186,7 @@ class AmplitudeExperimentPlugin
         private fun createExperimentClient(
             apiKey: String,
             experimentConfig: ExperimentConfig,
-        ): ExperimentClient =
-            DefaultExperimentClient(
-                apiKey,
-                experimentConfig,
-                Experiment.httpClient,
-                SharedPrefsStorage(applicationContext),
-                Experiment.executorService,
-            )
+        ): ExperimentClient = Experiment.createClient(applicationContext, apiKey, experimentConfig)
 
         private fun maybeStartLocked(): Boolean {
             if (started || stoppedDueToOptOut) {

--- a/sdk/src/main/java/com/amplitude/experiment/AmplitudeExperimentPlugin.kt
+++ b/sdk/src/main/java/com/amplitude/experiment/AmplitudeExperimentPlugin.kt
@@ -1,0 +1,246 @@
+package com.amplitude.experiment
+
+import android.content.Context
+import com.amplitude.core.AmplitudeContext
+import com.amplitude.core.AnalyticsClient
+import com.amplitude.core.AnalyticsIdentity
+import com.amplitude.core.RestrictedAmplitudeFeature
+import com.amplitude.core.platform.UniversalPlugin
+import com.amplitude.core.remoteconfig.RemoteConfigClient
+import com.amplitude.experiment.storage.SharedPrefsStorage
+import com.amplitude.experiment.util.AmpLogger
+import okhttp3.OkHttpClient
+import com.amplitude.core.ServerZone as CoreServerZone
+
+/**
+ * A [UniversalPlugin] that hosts Experiment inside the unified Amplitude analytics client.
+ *
+ * Register with `amplitude.add(plugin)` on the unified client. Because [AmplitudeContext] does
+ * not carry an Android [Context], pass an application [Context] to this plugin's constructor for
+ * Experiment storage and device metadata.
+ *
+ * This is an additive entry point that parallels [Experiment.initializeWithAmplitudeAnalytics]
+ * without replacing it.
+ */
+class AmplitudeExperimentPlugin
+    @JvmOverloads
+    constructor(
+        context: Context,
+        private val config: ExperimentConfig = ExperimentConfig(),
+        private val deploymentKey: String? = null,
+        private val remoteConfigWaitTimeoutMs: Long = DEFAULT_REMOTE_CONFIG_WAIT_TIMEOUT_MS,
+    ) : UniversalPlugin {
+        override val name: String = PLUGIN_NAME
+
+        private val applicationContext: Context = context.applicationContext
+
+        @Volatile
+        var experimentClient: ExperimentClient? = null
+            private set
+
+        @Volatile
+        private var analyticsClient: AnalyticsClient? = null
+
+        @Volatile
+        private var userProvider: AnalyticsClientUserProvider? = null
+
+        @Volatile
+        private var setupGeneration: Int = 0
+
+        @Volatile
+        private var startedGeneration: Int = -1
+
+        @Volatile
+        private var stoppedDueToOptOut: Boolean = false
+
+        @OptIn(RestrictedAmplitudeFeature::class)
+        @Volatile
+        private var remoteConfigCallback: RemoteConfigClient.RemoteConfigCallback? = null
+
+        private val httpClient = OkHttpClient()
+
+        override fun setup(
+            client: AnalyticsClient,
+            context: AmplitudeContext,
+        ) {
+            invalidateCurrentGeneration()
+            val generation = setupGeneration
+            analyticsClient = client
+            stoppedDueToOptOut = client.optOut
+            val provider =
+                AnalyticsClientUserProvider(applicationContext) { analyticsClient }.also {
+                    it.sessionId = client.sessionId
+                    userProvider = it
+                }
+            val apiKey = deploymentKey ?: context.apiKey
+            AmpLogger.configure(config.logLevel, config.loggerProvider)
+            val experimentConfig =
+                config
+                    .copyToBuilder()
+                    .instanceName(context.instanceName)
+                    .serverZone(context.serverZone.toExperimentServerZone())
+                    .userProvider(provider)
+                    .exposureTrackingProvider(AnalyticsClientExposureTrackingProvider(client))
+                    .automaticFetchOnAmplitudeIdentityChange(false)
+                    .build()
+            val experiment =
+                DefaultExperimentClient(
+                    apiKey,
+                    experimentConfig,
+                    httpClient,
+                    SharedPrefsStorage(applicationContext),
+                    Experiment.executorService,
+                )
+            experimentClient = experiment
+            subscribeForRemoteConfigAndStart(context, generation, experiment, provider, client)
+        }
+
+        override fun onIdentityChanged(identity: AnalyticsIdentity) {
+            val client = experimentClient ?: return
+            val user = buildUser(identity, analyticsClient?.sessionId)
+            client.setUser(user)
+            if (config.automaticFetchOnAmplitudeIdentityChange) {
+                client.fetch(user)
+            }
+        }
+
+        override fun onSessionIdChanged(sessionId: Long) {
+            userProvider?.sessionId = sessionId
+            val client = experimentClient ?: return
+            val user = buildUser(analyticsClient?.identity, sessionId)
+            client.setUser(user)
+        }
+
+        override fun onOptOutChanged(optOut: Boolean) {
+            if (optOut) {
+                experimentClient?.stop()
+                stoppedDueToOptOut = true
+                return
+            }
+            if (!stoppedDueToOptOut) {
+                return
+            }
+            stoppedDueToOptOut = false
+            val experiment = experimentClient ?: return
+            val analytics = analyticsClient ?: return
+            if (startedGeneration != setupGeneration) {
+                return
+            }
+            val provider = userProvider ?: return
+            provider.sessionId = analytics.sessionId
+            val user = buildUser(analytics.identity, analytics.sessionId)
+            experiment.setUser(user)
+            experiment.start(user)
+        }
+
+        override fun onReset() {
+            experimentClient?.clear()
+            experimentClient?.setUser(buildUser(analyticsClient?.identity, analyticsClient?.sessionId))
+        }
+
+        override fun teardown() {
+            invalidateCurrentGeneration()
+            analyticsClient = null
+        }
+
+        @OptIn(RestrictedAmplitudeFeature::class)
+        private fun invalidateCurrentGeneration() {
+            setupGeneration++
+            remoteConfigCallback = null
+            experimentClient?.stop()
+            experimentClient = null
+            userProvider = null
+            startedGeneration = -1
+            stoppedDueToOptOut = false
+        }
+
+        @OptIn(RestrictedAmplitudeFeature::class)
+        private fun subscribeForRemoteConfigAndStart(
+            context: AmplitudeContext,
+            generation: Int,
+            experiment: DefaultExperimentClient,
+            provider: AnalyticsClientUserProvider,
+            client: AnalyticsClient,
+        ) {
+            // TODO(SDKA-5): switch to RemoteConfigClient.Key.Experiment once the dedicated key
+            // lands on analytics-core.
+            val callback =
+                RemoteConfigClient.RemoteConfigCallback { _, _, _ ->
+                    if (generation != setupGeneration) {
+                        return@RemoteConfigCallback
+                    }
+                    startAfterRemoteConfig(generation, experiment, provider, client)
+                }
+            remoteConfigCallback = callback
+            context.remoteConfigClient.subscribe(
+                RemoteConfigClient.Key.Custom(EXPERIMENT_REMOTE_CONFIG_KEY),
+                RemoteConfigClient.DeliveryMode.WaitForRemote(remoteConfigWaitTimeoutMs),
+                callback,
+            )
+        }
+
+        private fun startAfterRemoteConfig(
+            generation: Int,
+            experiment: DefaultExperimentClient,
+            provider: AnalyticsClientUserProvider,
+            client: AnalyticsClient,
+        ) {
+            if (generation != setupGeneration) {
+                return
+            }
+            synchronized(this) {
+                if (generation != setupGeneration || startedGeneration == generation) {
+                    return
+                }
+                startedGeneration = generation
+            }
+            if (client.optOut) {
+                stoppedDueToOptOut = true
+                return
+            }
+            provider.sessionId = client.sessionId
+            val user = buildUser(client.identity, client.sessionId)
+            experiment.setUser(user)
+            experiment.start(user)
+        }
+
+        private fun buildUser(
+            identity: AnalyticsIdentity?,
+            sessionId: Long?,
+        ): ExperimentUser {
+            val resolvedSessionId = sessionId ?: analyticsClient?.sessionId
+            resolvedSessionId?.let { userProvider?.sessionId = it }
+            val builder = (userProvider?.deviceUser() ?: ExperimentUser()).copyToBuilder()
+            if (identity != null) {
+                builder
+                    .userId(identity.userId)
+                    .deviceId(identity.deviceId)
+                    .userProperties(identity.userProperties)
+            } else {
+                analyticsClient?.identity?.let { analyticsIdentity ->
+                    builder
+                        .userId(analyticsIdentity.userId)
+                        .deviceId(analyticsIdentity.deviceId)
+                        .userProperties(analyticsIdentity.userProperties)
+                }
+            }
+            resolvedSessionId?.let {
+                builder.userProperty(AnalyticsClientUserProvider.SESSION_ID_USER_PROPERTY, it)
+            }
+            return builder.build()
+        }
+
+        private fun CoreServerZone.toExperimentServerZone(): ServerZone =
+            when (this) {
+                CoreServerZone.EU -> ServerZone.EU
+                CoreServerZone.US -> ServerZone.US
+            }
+
+        companion object {
+            const val PLUGIN_NAME = "com.amplitude.experiment"
+            const val DEFAULT_REMOTE_CONFIG_WAIT_TIMEOUT_MS = 3_000L
+
+            // TODO(SDKA-5): replace with RemoteConfigClient.Key.Experiment when available.
+            private const val EXPERIMENT_REMOTE_CONFIG_KEY = "experiment.androidSDK"
+        }
+    }

--- a/sdk/src/main/java/com/amplitude/experiment/AmplitudeExperimentPlugin.kt
+++ b/sdk/src/main/java/com/amplitude/experiment/AmplitudeExperimentPlugin.kt
@@ -4,9 +4,7 @@ import android.content.Context
 import com.amplitude.core.AmplitudeContext
 import com.amplitude.core.AnalyticsClient
 import com.amplitude.core.AnalyticsIdentity
-import com.amplitude.core.RestrictedAmplitudeFeature
 import com.amplitude.core.platform.UniversalPlugin
-import com.amplitude.core.remoteconfig.RemoteConfigClient
 import com.amplitude.experiment.storage.SharedPrefsStorage
 import com.amplitude.experiment.util.AmpLogger
 import okhttp3.OkHttpClient
@@ -20,7 +18,8 @@ import com.amplitude.core.ServerZone as CoreServerZone
  * Experiment storage and device metadata.
  *
  * This is an additive entry point that parallels [Experiment.initializeWithAmplitudeAnalytics]
- * without replacing it.
+ * without replacing it. Behavior matches the iOS/Web Experiment plugins: initialize (and start)
+ * during [setup] with no remote-config gate.
  */
 class AmplitudeExperimentPlugin
     @JvmOverloads
@@ -28,7 +27,6 @@ class AmplitudeExperimentPlugin
         context: Context,
         private val config: ExperimentConfig = ExperimentConfig(),
         private val deploymentKey: String? = null,
-        private val remoteConfigWaitTimeoutMs: Long = DEFAULT_REMOTE_CONFIG_WAIT_TIMEOUT_MS,
     ) : UniversalPlugin {
         override val name: String =
             deploymentKey?.let { "${PLUGIN_NAME}_$it" } ?: PLUGIN_NAME
@@ -47,17 +45,7 @@ class AmplitudeExperimentPlugin
         private var userProvider: AnalyticsClientUserProvider? = null
 
         @Volatile
-        private var setupGeneration: Int = 0
-
-        @Volatile
-        private var startedGeneration: Int = -1
-
-        @Volatile
         private var stoppedDueToOptOut: Boolean = false
-
-        @OptIn(RestrictedAmplitudeFeature::class)
-        @Volatile
-        private var remoteConfigCallback: RemoteConfigClient.RemoteConfigCallback? = null
 
         private val httpClient = OkHttpClient()
 
@@ -66,8 +54,7 @@ class AmplitudeExperimentPlugin
             context: AmplitudeContext,
         ) {
             synchronized(lifecycleLock) {
-                invalidateCurrentGeneration()
-                val generation = setupGeneration
+                teardownLocked()
                 analyticsClient = client
                 stoppedDueToOptOut = client.optOut
                 val provider =
@@ -95,7 +82,11 @@ class AmplitudeExperimentPlugin
                         Experiment.executorService,
                     )
                 experimentClient = experiment
-                subscribeForRemoteConfigAndStart(context, generation, experiment, provider, client)
+                if (!client.optOut) {
+                    val user = buildUser(client.identity, client.sessionId)
+                    experiment.setUser(user)
+                    experiment.start(user)
+                }
             }
         }
 
@@ -104,10 +95,7 @@ class AmplitudeExperimentPlugin
                 val client = experimentClient ?: return
                 val user = buildUser(identity, analyticsClient?.sessionId)
                 client.setUser(user)
-                if (config.automaticFetchOnAmplitudeIdentityChange &&
-                    startedGeneration == setupGeneration &&
-                    !stoppedDueToOptOut
-                ) {
+                if (config.automaticFetchOnAmplitudeIdentityChange && !stoppedDueToOptOut) {
                     client.fetch(user)
                 }
             }
@@ -135,9 +123,6 @@ class AmplitudeExperimentPlugin
                 stoppedDueToOptOut = false
                 val experiment = experimentClient ?: return
                 val analytics = analyticsClient ?: return
-                if (startedGeneration != setupGeneration) {
-                    return
-                }
                 val provider = userProvider ?: return
                 provider.sessionId = analytics.sessionId
                 val user = buildUser(analytics.identity, analytics.sessionId)
@@ -155,67 +140,16 @@ class AmplitudeExperimentPlugin
 
         override fun teardown() {
             synchronized(lifecycleLock) {
-                invalidateCurrentGeneration()
+                teardownLocked()
             }
         }
 
-        @OptIn(RestrictedAmplitudeFeature::class)
-        private fun invalidateCurrentGeneration() {
-            setupGeneration++
-            remoteConfigCallback = null
+        private fun teardownLocked() {
             experimentClient?.stop()
             experimentClient = null
             analyticsClient = null
             userProvider = null
-            startedGeneration = -1
             stoppedDueToOptOut = false
-        }
-
-        @OptIn(RestrictedAmplitudeFeature::class)
-        private fun subscribeForRemoteConfigAndStart(
-            context: AmplitudeContext,
-            generation: Int,
-            experiment: DefaultExperimentClient,
-            provider: AnalyticsClientUserProvider,
-            client: AnalyticsClient,
-        ) {
-            // TODO(SDKA-5): switch to RemoteConfigClient.Key.Experiment once the dedicated key
-            // lands on analytics-core.
-            val callback =
-                RemoteConfigClient.RemoteConfigCallback { _, _, _ ->
-                    if (generation != setupGeneration) {
-                        return@RemoteConfigCallback
-                    }
-                    startAfterRemoteConfig(generation, experiment, provider, client)
-                }
-            remoteConfigCallback = callback
-            context.remoteConfigClient.subscribe(
-                RemoteConfigClient.Key.Custom(EXPERIMENT_REMOTE_CONFIG_KEY),
-                RemoteConfigClient.DeliveryMode.WaitForRemote(remoteConfigWaitTimeoutMs),
-                callback,
-            )
-        }
-
-        private fun startAfterRemoteConfig(
-            generation: Int,
-            experiment: DefaultExperimentClient,
-            provider: AnalyticsClientUserProvider,
-            client: AnalyticsClient,
-        ) {
-            synchronized(lifecycleLock) {
-                if (generation != setupGeneration || startedGeneration == generation) {
-                    return
-                }
-                startedGeneration = generation
-                if (client.optOut) {
-                    stoppedDueToOptOut = true
-                    return
-                }
-                provider.sessionId = client.sessionId
-                val user = buildUser(client.identity, client.sessionId)
-                experiment.setUser(user)
-                experiment.start(user)
-            }
         }
 
         private fun buildUser(
@@ -252,9 +186,5 @@ class AmplitudeExperimentPlugin
 
         companion object {
             const val PLUGIN_NAME = "com.amplitude.experiment"
-            const val DEFAULT_REMOTE_CONFIG_WAIT_TIMEOUT_MS = 3_000L
-
-            // TODO(SDKA-5): replace with RemoteConfigClient.Key.Experiment when available.
-            private const val EXPERIMENT_REMOTE_CONFIG_KEY = "experiment.androidSDK"
         }
     }

--- a/sdk/src/main/java/com/amplitude/experiment/AmplitudeExperimentPlugin.kt
+++ b/sdk/src/main/java/com/amplitude/experiment/AmplitudeExperimentPlugin.kt
@@ -1,5 +1,6 @@
 package com.amplitude.experiment
 
+import android.app.Application
 import android.content.Context
 import com.amplitude.analytics.connector.AnalyticsConnector
 import com.amplitude.analytics.connector.Identity
@@ -7,22 +8,25 @@ import com.amplitude.analytics.connector.IdentityListener
 import com.amplitude.core.AmplitudeContext
 import com.amplitude.core.AnalyticsClient
 import com.amplitude.core.AnalyticsIdentity
+import com.amplitude.core.events.AnalyticsEvent
 import com.amplitude.core.platform.UniversalPlugin
 import com.amplitude.experiment.storage.SharedPrefsStorage
 import com.amplitude.experiment.util.AmpLogger
-import okhttp3.OkHttpClient
 import com.amplitude.core.ServerZone as CoreServerZone
 
 /**
- * A [UniversalPlugin] that hosts Experiment inside the unified Amplitude analytics client.
+ * A [UniversalPlugin] that hosts Experiment inside a unified Amplitude analytics client.
  *
  * Register with `amplitude.add(plugin)` on the unified client. Because [AmplitudeContext] does
  * not carry an Android [Context], pass an application [Context] to this plugin's constructor for
  * Experiment storage and device metadata.
  *
  * This is an additive entry point that parallels [Experiment.initializeWithAmplitudeAnalytics]
- * without replacing it. Behavior matches the iOS/Web Experiment plugins: initialize (and start)
- * during [setup] with no remote-config gate.
+ * without replacing it. Behavior matches the iOS Experiment plugin: initialize during [setup]
+ * and start only after the host identity and session are ready. There is no remote-config gate.
+ *
+ * [ExperimentClient.stop] only stops flag polling; [ExperimentClient.variant] still evaluates
+ * locally while the host is opted out.
  */
 class AmplitudeExperimentPlugin
     @JvmOverloads
@@ -51,12 +55,22 @@ class AmplitudeExperimentPlugin
         private var stoppedDueToOptOut: Boolean = false
 
         @Volatile
+        private var started: Boolean = false
+
+        @Volatile
         private var connectorInstanceName: String? = null
 
         @Volatile
         private var connectorIdentityListener: IdentityListener? = null
 
-        private val httpClient = OkHttpClient()
+        @Volatile
+        private var lastConnectorUserId: String? = null
+
+        @Volatile
+        private var lastConnectorDeviceId: String? = null
+
+        @Volatile
+        private var lastConnectorUserProperties: Map<String, Any?> = emptyMap()
 
         override fun setup(
             client: AnalyticsClient,
@@ -73,7 +87,7 @@ class AmplitudeExperimentPlugin
                         { analyticsClient },
                         context.instanceName,
                     ).also {
-                        it.sessionId = client.sessionId
+                        it.sessionId = client.sessionId.takeUnless { sessionId -> sessionId == UNINITIALIZED_SESSION_ID }
                         userProvider = it
                     }
                 val apiKey = deploymentKey ?: context.apiKey
@@ -85,30 +99,18 @@ class AmplitudeExperimentPlugin
                         .serverZone(context.serverZone.toExperimentServerZone())
                         .userProvider(provider)
                         .exposureTrackingProvider(AnalyticsClientExposureTrackingProvider { analyticsClient })
-                        // Plugin owns identity-driven fetches via UniversalPlugin + connector.
-                        .automaticFetchOnAmplitudeIdentityChange(false)
+                        .automaticFetchOnAmplitudeIdentityChange(
+                            config.automaticFetchOnAmplitudeIdentityChange,
+                        )
                         .build()
-                val experiment =
-                    DefaultExperimentClient(
-                        apiKey,
-                        experimentConfig,
-                        httpClient,
-                        SharedPrefsStorage(applicationContext),
-                        Experiment.executorService,
-                    )
-                experimentClient = experiment
+                experimentClient = createExperimentClient(apiKey, experimentConfig)
                 if (config.automaticFetchOnAmplitudeIdentityChange) {
-                    // Match initializeWithAmplitudeAnalytics: connector commits include identify
-                    // $set updates that UniversalPlugin onIdentityChanged does not receive.
-                    val listener: IdentityListener = { _: Identity ->
+                    // Identify $set updates commit to the connector only; UniversalPlugin
+                    // onIdentityChanged does not receive user-property maps on Amplitude-Kotlin.
+                    snapshotConnectorIdentity(context.instanceName)
+                    val listener: IdentityListener = { identity: Identity ->
                         synchronized(lifecycleLock) {
-                            if (stoppedDueToOptOut) return@synchronized
-                            val client = experimentClient ?: return@synchronized
-                            // Refresh the cached user from the provider before fetch so identify
-                            // $set updates (connector-only) are not masked by a stale setUser snapshot.
-                            val user = buildUser(analyticsClient?.identity, analyticsClient?.sessionId)
-                            client.setUser(user)
-                            client.fetch(user)
+                            handleConnectorIdentity(identity)
                         }
                     }
                     connectorIdentityListener = listener
@@ -116,20 +118,22 @@ class AmplitudeExperimentPlugin
                         .identityStore
                         .addIdentityListener(listener)
                 }
-                if (!client.optOut) {
-                    val user = buildUser(client.identity, client.sessionId)
-                    experiment.setUser(user)
-                    experiment.start(user)
-                }
+                maybeStartLocked()
             }
         }
+
+        override fun <T : AnalyticsEvent> execute(event: T): T? = event
 
         override fun onIdentityChanged(identity: AnalyticsIdentity) {
             synchronized(lifecycleLock) {
                 val client = experimentClient ?: return
                 val user = buildUser(identity, analyticsClient?.sessionId)
                 client.setUser(user)
-                if (config.automaticFetchOnAmplitudeIdentityChange && !stoppedDueToOptOut) {
+                if (!maybeStartLocked() &&
+                    config.automaticFetchOnAmplitudeIdentityChange &&
+                    started &&
+                    !stoppedDueToOptOut
+                ) {
                     client.fetch(user)
                 }
             }
@@ -137,10 +141,11 @@ class AmplitudeExperimentPlugin
 
         override fun onSessionIdChanged(sessionId: Long) {
             synchronized(lifecycleLock) {
-                userProvider?.sessionId = sessionId
+                userProvider?.sessionId = sessionId.takeUnless { it == UNINITIALIZED_SESSION_ID }
                 val client = experimentClient ?: return
                 val user = buildUser(analyticsClient?.identity, sessionId)
                 client.setUser(user)
+                maybeStartLocked()
             }
         }
 
@@ -149,32 +154,26 @@ class AmplitudeExperimentPlugin
                 if (optOut) {
                     experimentClient?.stop()
                     stoppedDueToOptOut = true
+                    started = false
                     return
                 }
                 if (!stoppedDueToOptOut) {
                     return
                 }
                 stoppedDueToOptOut = false
-                val experiment = experimentClient ?: return
-                val analytics = analyticsClient ?: return
-                val provider = userProvider ?: return
-                provider.sessionId = analytics.sessionId
-                val user = buildUser(analytics.identity, analytics.sessionId)
-                experiment.setUser(user)
-                experiment.start(user)
+                maybeStartLocked()
             }
         }
 
         override fun onReset() {
             synchronized(lifecycleLock) {
                 val experiment = experimentClient ?: return
-                // Host reset notifies onIdentityChanged then onReset. Identity change may not
-                // fetch (automaticFetch defaults false), and clear() would wipe any prior fetch,
-                // so always clear + setUser + fetch for the post-reset identity when not opted out.
+                // Host reset notifies onIdentityChanged then onReset. Clear assignments that
+                // belonged to the previous user; fetch only when automatic identity fetch is on.
                 experiment.clear()
                 val user = buildUser(analyticsClient?.identity, analyticsClient?.sessionId)
                 experiment.setUser(user)
-                if (!stoppedDueToOptOut) {
+                if (config.automaticFetchOnAmplitudeIdentityChange && !stoppedDueToOptOut) {
                     experiment.fetch(user)
                 }
             }
@@ -184,6 +183,77 @@ class AmplitudeExperimentPlugin
             synchronized(lifecycleLock) {
                 teardownLocked()
             }
+        }
+
+        private fun createExperimentClient(
+            apiKey: String,
+            experimentConfig: ExperimentConfig,
+        ): ExperimentClient {
+            val application = applicationContext as? Application
+            return if (application != null) {
+                Experiment.initialize(application, apiKey, experimentConfig)
+            } else {
+                DefaultExperimentClient(
+                    apiKey,
+                    experimentConfig,
+                    Experiment.httpClient,
+                    SharedPrefsStorage(applicationContext),
+                    Experiment.executorService,
+                )
+            }
+        }
+
+        private fun maybeStartLocked(): Boolean {
+            if (started || stoppedDueToOptOut) {
+                return false
+            }
+            val experiment = experimentClient ?: return false
+            val analytics = analyticsClient ?: return false
+            if (analytics.optOut || !isHostIdentityReady(analytics)) {
+                return false
+            }
+            val provider = userProvider ?: return false
+            provider.sessionId = analytics.sessionId
+            val user = buildUser(analytics.identity, analytics.sessionId)
+            experiment.setUser(user)
+            experiment.start(user)
+            started = true
+            return true
+        }
+
+        private fun isHostIdentityReady(client: AnalyticsClient): Boolean {
+            val deviceId = client.identity.deviceId
+            return !deviceId.isNullOrEmpty() && client.sessionId != UNINITIALIZED_SESSION_ID
+        }
+
+        private fun snapshotConnectorIdentity(instanceName: String) {
+            val identity =
+                try {
+                    AnalyticsConnector.getInstance(instanceName).identityStore.getIdentity()
+                } catch (_: Exception) {
+                    return
+                }
+            lastConnectorUserId = identity.userId
+            lastConnectorDeviceId = identity.deviceId
+            lastConnectorUserProperties = identity.userProperties.toMap()
+        }
+
+        private fun handleConnectorIdentity(identity: Identity) {
+            if (stoppedDueToOptOut) return
+            val client = experimentClient ?: return
+            val userIdChanged = identity.userId != lastConnectorUserId
+            val deviceIdChanged = identity.deviceId != lastConnectorDeviceId
+            val propertiesChanged = identity.userProperties != lastConnectorUserProperties
+            lastConnectorUserId = identity.userId
+            lastConnectorDeviceId = identity.deviceId
+            lastConnectorUserProperties = identity.userProperties.toMap()
+            // User/device id changes are handled by UniversalPlugin.onIdentityChanged.
+            if (userIdChanged || deviceIdChanged || !propertiesChanged) {
+                return
+            }
+            val user = buildUser(analyticsClient?.identity, analyticsClient?.sessionId)
+            client.setUser(user)
+            client.fetch(user)
         }
 
         private fun teardownLocked() {
@@ -196,18 +266,24 @@ class AmplitudeExperimentPlugin
             }
             connectorIdentityListener = null
             connectorInstanceName = null
+            lastConnectorUserId = null
+            lastConnectorDeviceId = null
+            lastConnectorUserProperties = emptyMap()
             experimentClient?.stop()
             experimentClient = null
             analyticsClient = null
             userProvider = null
             stoppedDueToOptOut = false
+            started = false
         }
 
         private fun buildUser(
             identity: AnalyticsIdentity?,
             sessionId: Long?,
         ): ExperimentUser {
-            val resolvedSessionId = sessionId ?: analyticsClient?.sessionId
+            val resolvedSessionId =
+                (sessionId ?: analyticsClient?.sessionId)
+                    ?.takeUnless { it == UNINITIALIZED_SESSION_ID }
             resolvedSessionId?.let { userProvider?.sessionId = it }
             // Prefer the user provider so connector-backed user properties are preserved when
             // AnalyticsIdentity.userProperties is empty (Amplitude-Kotlin today).
@@ -232,5 +308,6 @@ class AmplitudeExperimentPlugin
 
         companion object {
             const val PLUGIN_NAME = "com.amplitude.experiment"
+            private const val UNINITIALIZED_SESSION_ID = -1L
         }
     }

--- a/sdk/src/main/java/com/amplitude/experiment/AmplitudeExperimentPlugin.kt
+++ b/sdk/src/main/java/com/amplitude/experiment/AmplitudeExperimentPlugin.kt
@@ -30,9 +30,11 @@ class AmplitudeExperimentPlugin
         private val deploymentKey: String? = null,
         private val remoteConfigWaitTimeoutMs: Long = DEFAULT_REMOTE_CONFIG_WAIT_TIMEOUT_MS,
     ) : UniversalPlugin {
-        override val name: String = PLUGIN_NAME
+        override val name: String =
+            deploymentKey?.let { "${PLUGIN_NAME}_$it" } ?: PLUGIN_NAME
 
-        private val applicationContext: Context = context.applicationContext
+        private val applicationContext: Context = context.applicationContext ?: context
+        private val lifecycleLock = Any()
 
         @Volatile
         var experimentClient: ExperimentClient? = null
@@ -63,84 +65,98 @@ class AmplitudeExperimentPlugin
             client: AnalyticsClient,
             context: AmplitudeContext,
         ) {
-            invalidateCurrentGeneration()
-            val generation = setupGeneration
-            analyticsClient = client
-            stoppedDueToOptOut = client.optOut
-            val provider =
-                AnalyticsClientUserProvider(applicationContext) { analyticsClient }.also {
-                    it.sessionId = client.sessionId
-                    userProvider = it
-                }
-            val apiKey = deploymentKey ?: context.apiKey
-            AmpLogger.configure(config.logLevel, config.loggerProvider)
-            val experimentConfig =
-                config
-                    .copyToBuilder()
-                    .instanceName(context.instanceName)
-                    .serverZone(context.serverZone.toExperimentServerZone())
-                    .userProvider(provider)
-                    .exposureTrackingProvider(AnalyticsClientExposureTrackingProvider(client))
-                    .automaticFetchOnAmplitudeIdentityChange(false)
-                    .build()
-            val experiment =
-                DefaultExperimentClient(
-                    apiKey,
-                    experimentConfig,
-                    httpClient,
-                    SharedPrefsStorage(applicationContext),
-                    Experiment.executorService,
-                )
-            experimentClient = experiment
-            subscribeForRemoteConfigAndStart(context, generation, experiment, provider, client)
+            synchronized(lifecycleLock) {
+                invalidateCurrentGeneration()
+                val generation = setupGeneration
+                analyticsClient = client
+                stoppedDueToOptOut = client.optOut
+                val provider =
+                    AnalyticsClientUserProvider(applicationContext) { analyticsClient }.also {
+                        it.sessionId = client.sessionId
+                        userProvider = it
+                    }
+                val apiKey = deploymentKey ?: context.apiKey
+                AmpLogger.configure(config.logLevel, config.loggerProvider)
+                val experimentConfig =
+                    config
+                        .copyToBuilder()
+                        .instanceName(context.instanceName)
+                        .serverZone(context.serverZone.toExperimentServerZone())
+                        .userProvider(provider)
+                        .exposureTrackingProvider(AnalyticsClientExposureTrackingProvider { analyticsClient })
+                        .automaticFetchOnAmplitudeIdentityChange(false)
+                        .build()
+                val experiment =
+                    DefaultExperimentClient(
+                        apiKey,
+                        experimentConfig,
+                        httpClient,
+                        SharedPrefsStorage(applicationContext),
+                        Experiment.executorService,
+                    )
+                experimentClient = experiment
+                subscribeForRemoteConfigAndStart(context, generation, experiment, provider, client)
+            }
         }
 
         override fun onIdentityChanged(identity: AnalyticsIdentity) {
-            val client = experimentClient ?: return
-            val user = buildUser(identity, analyticsClient?.sessionId)
-            client.setUser(user)
-            if (config.automaticFetchOnAmplitudeIdentityChange) {
-                client.fetch(user)
+            synchronized(lifecycleLock) {
+                val client = experimentClient ?: return
+                val user = buildUser(identity, analyticsClient?.sessionId)
+                client.setUser(user)
+                if (config.automaticFetchOnAmplitudeIdentityChange &&
+                    startedGeneration == setupGeneration &&
+                    !stoppedDueToOptOut
+                ) {
+                    client.fetch(user)
+                }
             }
         }
 
         override fun onSessionIdChanged(sessionId: Long) {
-            userProvider?.sessionId = sessionId
-            val client = experimentClient ?: return
-            val user = buildUser(analyticsClient?.identity, sessionId)
-            client.setUser(user)
+            synchronized(lifecycleLock) {
+                userProvider?.sessionId = sessionId
+                val client = experimentClient ?: return
+                val user = buildUser(analyticsClient?.identity, sessionId)
+                client.setUser(user)
+            }
         }
 
         override fun onOptOutChanged(optOut: Boolean) {
-            if (optOut) {
-                experimentClient?.stop()
-                stoppedDueToOptOut = true
-                return
+            synchronized(lifecycleLock) {
+                if (optOut) {
+                    experimentClient?.stop()
+                    stoppedDueToOptOut = true
+                    return
+                }
+                if (!stoppedDueToOptOut) {
+                    return
+                }
+                stoppedDueToOptOut = false
+                val experiment = experimentClient ?: return
+                val analytics = analyticsClient ?: return
+                if (startedGeneration != setupGeneration) {
+                    return
+                }
+                val provider = userProvider ?: return
+                provider.sessionId = analytics.sessionId
+                val user = buildUser(analytics.identity, analytics.sessionId)
+                experiment.setUser(user)
+                experiment.start(user)
             }
-            if (!stoppedDueToOptOut) {
-                return
-            }
-            stoppedDueToOptOut = false
-            val experiment = experimentClient ?: return
-            val analytics = analyticsClient ?: return
-            if (startedGeneration != setupGeneration) {
-                return
-            }
-            val provider = userProvider ?: return
-            provider.sessionId = analytics.sessionId
-            val user = buildUser(analytics.identity, analytics.sessionId)
-            experiment.setUser(user)
-            experiment.start(user)
         }
 
         override fun onReset() {
-            experimentClient?.clear()
-            experimentClient?.setUser(buildUser(analyticsClient?.identity, analyticsClient?.sessionId))
+            synchronized(lifecycleLock) {
+                experimentClient?.clear()
+                experimentClient?.setUser(buildUser(analyticsClient?.identity, analyticsClient?.sessionId))
+            }
         }
 
         override fun teardown() {
-            invalidateCurrentGeneration()
-            analyticsClient = null
+            synchronized(lifecycleLock) {
+                invalidateCurrentGeneration()
+            }
         }
 
         @OptIn(RestrictedAmplitudeFeature::class)
@@ -149,6 +165,7 @@ class AmplitudeExperimentPlugin
             remoteConfigCallback = null
             experimentClient?.stop()
             experimentClient = null
+            analyticsClient = null
             userProvider = null
             startedGeneration = -1
             stoppedDueToOptOut = false
@@ -185,23 +202,20 @@ class AmplitudeExperimentPlugin
             provider: AnalyticsClientUserProvider,
             client: AnalyticsClient,
         ) {
-            if (generation != setupGeneration) {
-                return
-            }
-            synchronized(this) {
+            synchronized(lifecycleLock) {
                 if (generation != setupGeneration || startedGeneration == generation) {
                     return
                 }
                 startedGeneration = generation
+                if (client.optOut) {
+                    stoppedDueToOptOut = true
+                    return
+                }
+                provider.sessionId = client.sessionId
+                val user = buildUser(client.identity, client.sessionId)
+                experiment.setUser(user)
+                experiment.start(user)
             }
-            if (client.optOut) {
-                stoppedDueToOptOut = true
-                return
-            }
-            provider.sessionId = client.sessionId
-            val user = buildUser(client.identity, client.sessionId)
-            experiment.setUser(user)
-            experiment.start(user)
         }
 
         private fun buildUser(

--- a/sdk/src/main/java/com/amplitude/experiment/AmplitudeExperimentPlugin.kt
+++ b/sdk/src/main/java/com/amplitude/experiment/AmplitudeExperimentPlugin.kt
@@ -1,6 +1,9 @@
 package com.amplitude.experiment
 
 import android.content.Context
+import com.amplitude.analytics.connector.AnalyticsConnector
+import com.amplitude.analytics.connector.Identity
+import com.amplitude.analytics.connector.IdentityListener
 import com.amplitude.core.AmplitudeContext
 import com.amplitude.core.AnalyticsClient
 import com.amplitude.core.AnalyticsIdentity
@@ -47,6 +50,12 @@ class AmplitudeExperimentPlugin
         @Volatile
         private var stoppedDueToOptOut: Boolean = false
 
+        @Volatile
+        private var connectorInstanceName: String? = null
+
+        @Volatile
+        private var connectorIdentityListener: IdentityListener? = null
+
         private val httpClient = OkHttpClient()
 
         override fun setup(
@@ -57,8 +66,13 @@ class AmplitudeExperimentPlugin
                 teardownLocked()
                 analyticsClient = client
                 stoppedDueToOptOut = client.optOut
+                connectorInstanceName = context.instanceName
                 val provider =
-                    AnalyticsClientUserProvider(applicationContext) { analyticsClient }.also {
+                    AnalyticsClientUserProvider(
+                        applicationContext,
+                        { analyticsClient },
+                        context.instanceName,
+                    ).also {
                         it.sessionId = client.sessionId
                         userProvider = it
                     }
@@ -71,6 +85,7 @@ class AmplitudeExperimentPlugin
                         .serverZone(context.serverZone.toExperimentServerZone())
                         .userProvider(provider)
                         .exposureTrackingProvider(AnalyticsClientExposureTrackingProvider { analyticsClient })
+                        // Plugin owns identity-driven fetches via UniversalPlugin + connector.
                         .automaticFetchOnAmplitudeIdentityChange(false)
                         .build()
                 val experiment =
@@ -82,6 +97,25 @@ class AmplitudeExperimentPlugin
                         Experiment.executorService,
                     )
                 experimentClient = experiment
+                if (config.automaticFetchOnAmplitudeIdentityChange) {
+                    // Match initializeWithAmplitudeAnalytics: connector commits include identify
+                    // $set updates that UniversalPlugin onIdentityChanged does not receive.
+                    val listener: IdentityListener = { _: Identity ->
+                        synchronized(lifecycleLock) {
+                            if (stoppedDueToOptOut) return@synchronized
+                            val client = experimentClient ?: return@synchronized
+                            // Refresh the cached user from the provider before fetch so identify
+                            // $set updates (connector-only) are not masked by a stale setUser snapshot.
+                            val user = buildUser(analyticsClient?.identity, analyticsClient?.sessionId)
+                            client.setUser(user)
+                            client.fetch(user)
+                        }
+                    }
+                    connectorIdentityListener = listener
+                    AnalyticsConnector.getInstance(context.instanceName)
+                        .identityStore
+                        .addIdentityListener(listener)
+                }
                 if (!client.optOut) {
                     val user = buildUser(client.identity, client.sessionId)
                     experiment.setUser(user)
@@ -133,8 +167,16 @@ class AmplitudeExperimentPlugin
 
         override fun onReset() {
             synchronized(lifecycleLock) {
-                experimentClient?.clear()
-                experimentClient?.setUser(buildUser(analyticsClient?.identity, analyticsClient?.sessionId))
+                val experiment = experimentClient ?: return
+                // Host reset notifies onIdentityChanged then onReset. Identity change may not
+                // fetch (automaticFetch defaults false), and clear() would wipe any prior fetch,
+                // so always clear + setUser + fetch for the post-reset identity when not opted out.
+                experiment.clear()
+                val user = buildUser(analyticsClient?.identity, analyticsClient?.sessionId)
+                experiment.setUser(user)
+                if (!stoppedDueToOptOut) {
+                    experiment.fetch(user)
+                }
             }
         }
 
@@ -145,6 +187,15 @@ class AmplitudeExperimentPlugin
         }
 
         private fun teardownLocked() {
+            val listener = connectorIdentityListener
+            val instanceName = connectorInstanceName
+            if (listener != null && instanceName != null) {
+                AnalyticsConnector.getInstance(instanceName)
+                    .identityStore
+                    .removeIdentityListener(listener)
+            }
+            connectorIdentityListener = null
+            connectorInstanceName = null
             experimentClient?.stop()
             experimentClient = null
             analyticsClient = null
@@ -158,18 +209,13 @@ class AmplitudeExperimentPlugin
         ): ExperimentUser {
             val resolvedSessionId = sessionId ?: analyticsClient?.sessionId
             resolvedSessionId?.let { userProvider?.sessionId = it }
-            val builder = (userProvider?.deviceUser() ?: ExperimentUser()).copyToBuilder()
+            // Prefer the user provider so connector-backed user properties are preserved when
+            // AnalyticsIdentity.userProperties is empty (Amplitude-Kotlin today).
+            val builder = (userProvider?.getUser() ?: ExperimentUser()).copyToBuilder()
             if (identity != null) {
-                builder
-                    .userId(identity.userId)
-                    .deviceId(identity.deviceId)
-                    .userProperties(identity.userProperties)
-            } else {
-                analyticsClient?.identity?.let { analyticsIdentity ->
-                    builder
-                        .userId(analyticsIdentity.userId)
-                        .deviceId(analyticsIdentity.deviceId)
-                        .userProperties(analyticsIdentity.userProperties)
+                builder.userId(identity.userId).deviceId(identity.deviceId)
+                if (identity.userProperties.isNotEmpty()) {
+                    builder.userProperties(identity.userProperties)
                 }
             }
             resolvedSessionId?.let {

--- a/sdk/src/main/java/com/amplitude/experiment/AmplitudeExperimentPlugin.kt
+++ b/sdk/src/main/java/com/amplitude/experiment/AmplitudeExperimentPlugin.kt
@@ -1,6 +1,5 @@
 package com.amplitude.experiment
 
-import android.app.Application
 import android.content.Context
 import com.amplitude.analytics.connector.AnalyticsConnector
 import com.amplitude.analytics.connector.Identity
@@ -188,20 +187,14 @@ class AmplitudeExperimentPlugin
         private fun createExperimentClient(
             apiKey: String,
             experimentConfig: ExperimentConfig,
-        ): ExperimentClient {
-            val application = applicationContext as? Application
-            return if (application != null) {
-                Experiment.initialize(application, apiKey, experimentConfig)
-            } else {
-                DefaultExperimentClient(
-                    apiKey,
-                    experimentConfig,
-                    Experiment.httpClient,
-                    SharedPrefsStorage(applicationContext),
-                    Experiment.executorService,
-                )
-            }
-        }
+        ): ExperimentClient =
+            DefaultExperimentClient(
+                apiKey,
+                experimentConfig,
+                Experiment.httpClient,
+                SharedPrefsStorage(applicationContext),
+                Experiment.executorService,
+            )
 
         private fun maybeStartLocked(): Boolean {
             if (started || stoppedDueToOptOut) {
@@ -239,7 +232,7 @@ class AmplitudeExperimentPlugin
         }
 
         private fun handleConnectorIdentity(identity: Identity) {
-            if (stoppedDueToOptOut) return
+            if (!started || stoppedDueToOptOut) return
             val client = experimentClient ?: return
             val userIdChanged = identity.userId != lastConnectorUserId
             val deviceIdChanged = identity.deviceId != lastConnectorDeviceId

--- a/sdk/src/main/java/com/amplitude/experiment/AnalyticsClientExposureTrackingProvider.kt
+++ b/sdk/src/main/java/com/amplitude/experiment/AnalyticsClientExposureTrackingProvider.kt
@@ -3,9 +3,10 @@ package com.amplitude.experiment
 import com.amplitude.core.AnalyticsClient
 
 internal class AnalyticsClientExposureTrackingProvider(
-    private val client: AnalyticsClient,
+    private val clientProvider: () -> AnalyticsClient?,
 ) : ExposureTrackingProvider {
     override fun track(exposure: Exposure) {
+        val client = clientProvider() ?: return
         client.track(
             "\$exposure",
             mapOf(

--- a/sdk/src/main/java/com/amplitude/experiment/AnalyticsClientExposureTrackingProvider.kt
+++ b/sdk/src/main/java/com/amplitude/experiment/AnalyticsClientExposureTrackingProvider.kt
@@ -1,0 +1,23 @@
+package com.amplitude.experiment
+
+import com.amplitude.core.AnalyticsClient
+
+internal class AnalyticsClientExposureTrackingProvider(
+    private val client: AnalyticsClient,
+) : ExposureTrackingProvider {
+    override fun track(exposure: Exposure) {
+        client.track(
+            "\$exposure",
+            mapOf(
+                "flag_key" to exposure.flagKey,
+                "variant" to exposure.variant,
+                "experiment_key" to exposure.experimentKey,
+                "metadata" to exposure.metadata,
+            ).filterNullValues(),
+        )
+    }
+}
+
+private fun <T> Map<String, T?>.filterNullValues(): Map<String, T> {
+    return filterValues { it != null }.mapValues { it.value!! }
+}

--- a/sdk/src/main/java/com/amplitude/experiment/AnalyticsClientUserProvider.kt
+++ b/sdk/src/main/java/com/amplitude/experiment/AnalyticsClientUserProvider.kt
@@ -1,0 +1,40 @@
+package com.amplitude.experiment
+
+import android.content.Context
+import com.amplitude.core.AnalyticsClient
+
+internal class AnalyticsClientUserProvider(
+    context: Context,
+    private val clientProvider: () -> AnalyticsClient?,
+) : ExperimentUserProvider {
+    private val baseUserProvider: ExperimentUserProvider? =
+        try {
+            DefaultUserProvider(context)
+        } catch (e: Throwable) {
+            null
+        }
+
+    @Volatile
+    var sessionId: Long? = null
+
+    override fun getUser(): ExperimentUser {
+        val client = clientProvider() ?: return baseUser()
+        val identity = client.identity
+        val builder =
+            baseUser()
+                .copyToBuilder()
+                .userId(identity.userId)
+                .deviceId(identity.deviceId)
+                .userProperties(identity.userProperties)
+        sessionId?.let { builder.userProperty(SESSION_ID_USER_PROPERTY, it) }
+        return builder.build()
+    }
+
+    private fun baseUser(): ExperimentUser = baseUserProvider?.getUser() ?: ExperimentUser()
+
+    internal fun deviceUser(): ExperimentUser = baseUser()
+
+    internal companion object {
+        const val SESSION_ID_USER_PROPERTY = "session_id"
+    }
+}

--- a/sdk/src/main/java/com/amplitude/experiment/AnalyticsClientUserProvider.kt
+++ b/sdk/src/main/java/com/amplitude/experiment/AnalyticsClientUserProvider.kt
@@ -1,11 +1,14 @@
 package com.amplitude.experiment
 
 import android.content.Context
+import com.amplitude.analytics.connector.AnalyticsConnector
 import com.amplitude.core.AnalyticsClient
+import com.amplitude.core.AnalyticsIdentity
 
 internal class AnalyticsClientUserProvider(
     context: Context,
     private val clientProvider: () -> AnalyticsClient?,
+    private val instanceName: String = ExperimentConfig.Defaults.INSTANCE_NAME,
 ) : ExperimentUserProvider {
     private val baseUserProvider: ExperimentUserProvider? =
         try {
@@ -25,14 +28,33 @@ internal class AnalyticsClientUserProvider(
                 .copyToBuilder()
                 .userId(identity.userId)
                 .deviceId(identity.deviceId)
-                .userProperties(identity.userProperties)
+                .userProperties(resolveUserProperties(identity))
         sessionId?.let { builder.userProperty(SESSION_ID_USER_PROPERTY, it) }
         return builder.build()
     }
 
-    private fun baseUser(): ExperimentUser = baseUserProvider?.getUser() ?: ExperimentUser()
+    /**
+     * Prefer [AnalyticsIdentity.userProperties] when the host maintains a live map (iOS-style).
+     * Amplitude-Kotlin currently leaves that empty, so fall back to analytics-connector's
+     * [com.amplitude.analytics.connector.IdentityStore] — the same source
+     * [Experiment.initializeWithAmplitudeAnalytics] uses.
+     */
+    private fun resolveUserProperties(identity: AnalyticsIdentity): Map<String, Any?> {
+        if (identity.userProperties.isNotEmpty()) {
+            return identity.userProperties
+        }
+        return connectorUserProperties()
+    }
 
-    internal fun deviceUser(): ExperimentUser = baseUser()
+    private fun connectorUserProperties(): Map<String, Any?> {
+        return try {
+            AnalyticsConnector.getInstance(instanceName).identityStore.getIdentity().userProperties
+        } catch (_: Exception) {
+            emptyMap()
+        }
+    }
+
+    private fun baseUser(): ExperimentUser = baseUserProvider?.getUser() ?: ExperimentUser()
 
     internal companion object {
         const val SESSION_ID_USER_PROPERTY = "session_id"

--- a/sdk/src/main/java/com/amplitude/experiment/AnalyticsClientUserProvider.kt
+++ b/sdk/src/main/java/com/amplitude/experiment/AnalyticsClientUserProvider.kt
@@ -10,7 +10,7 @@ internal class AnalyticsClientUserProvider(
     private val baseUserProvider: ExperimentUserProvider? =
         try {
             DefaultUserProvider(context)
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
             null
         }
 

--- a/sdk/src/main/java/com/amplitude/experiment/Experiment.kt
+++ b/sdk/src/main/java/com/amplitude/experiment/Experiment.kt
@@ -1,6 +1,7 @@
 package com.amplitude.experiment
 
 import android.app.Application
+import android.content.Context
 import com.amplitude.analytics.connector.AnalyticsConnector
 import com.amplitude.experiment.storage.SharedPrefsStorage
 import com.amplitude.experiment.util.AmpLogger
@@ -16,10 +17,22 @@ object Experiment {
                 isDaemon = true
             }
         }
-    internal val executorService = ScheduledThreadPoolExecutor(4, daemonThreadFactory)
-
-    internal val httpClient = OkHttpClient()
+    private val executorService = ScheduledThreadPoolExecutor(4, daemonThreadFactory)
+    private val httpClient = OkHttpClient()
     private val instances = mutableMapOf<String, ExperimentClient>()
+
+    internal fun createClient(
+        context: Context,
+        apiKey: String,
+        config: ExperimentConfig,
+    ): DefaultExperimentClient =
+        DefaultExperimentClient(
+            apiKey,
+            config,
+            httpClient,
+            SharedPrefsStorage(context),
+            executorService,
+        )
 
     /**
      * Initializes a singleton [ExperimentClient] identified by the configured
@@ -50,14 +63,7 @@ object Experiment {
                                 .userProvider(DefaultUserProvider(application))
                                 .build()
                     }
-                    val newInstance =
-                        DefaultExperimentClient(
-                            apiKey,
-                            mergedConfig,
-                            httpClient,
-                            SharedPrefsStorage(application),
-                            executorService,
-                        )
+                    val newInstance = createClient(application, apiKey, mergedConfig)
                     instances[instanceKey] = newInstance
                     newInstance
                 }
@@ -103,14 +109,7 @@ object Experiment {
                                 ConnectorExposureTrackingProvider(connector.eventBridge),
                             )
                         }
-                        val newInstance =
-                            DefaultExperimentClient(
-                                apiKey,
-                                configBuilder.build(),
-                                httpClient,
-                                SharedPrefsStorage(application),
-                                executorService,
-                            )
+                        val newInstance = createClient(application, apiKey, configBuilder.build())
                         instances[instanceKey] = newInstance
                         if (config.automaticFetchOnAmplitudeIdentityChange) {
                             connector.identityStore.addIdentityListener {

--- a/sdk/src/main/java/com/amplitude/experiment/Experiment.kt
+++ b/sdk/src/main/java/com/amplitude/experiment/Experiment.kt
@@ -18,7 +18,7 @@ object Experiment {
         }
     internal val executorService = ScheduledThreadPoolExecutor(4, daemonThreadFactory)
 
-    private val httpClient = OkHttpClient()
+    internal val httpClient = OkHttpClient()
     private val instances = mutableMapOf<String, ExperimentClient>()
 
     /**

--- a/sdk/src/test/java/com/amplitude/experiment/AmplitudeExperimentPluginTest.kt
+++ b/sdk/src/test/java/com/amplitude/experiment/AmplitudeExperimentPluginTest.kt
@@ -9,11 +9,8 @@ import com.amplitude.core.diagnostics.DiagnosticsClient
 import com.amplitude.core.remoteconfig.RemoteConfigClient
 import com.amplitude.experiment.util.AmpLogger
 import com.amplitude.experiment.util.SystemLoggerProvider
-import io.mockk.Runs
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
-import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.verify
 import org.junit.Assert
@@ -78,6 +75,45 @@ class AmplitudeExperimentPluginTest {
     }
 
     @Test
+    fun `setup starts experiment client without remote config`() {
+        val plugin =
+            AmplitudeExperimentPlugin(
+                applicationContext,
+                ExperimentConfig(
+                    debug = true,
+                    fetchOnStart = false,
+                    pollOnStart = false,
+                ),
+            )
+
+        plugin.setup(analyticsClient, createContext())
+
+        Assert.assertNotNull(plugin.experimentClient?.getUser())
+        Assert.assertEquals("user-1", plugin.experimentClient?.getUser()?.userId)
+        Assert.assertEquals("device-1", plugin.experimentClient?.getUser()?.deviceId)
+        verify(exactly = 0) { remoteConfigClient.subscribe(any(), any(), any()) }
+    }
+
+    @Test
+    fun `setup does not start when opted out`() {
+        every { analyticsClient.optOut } returns true
+        val plugin =
+            AmplitudeExperimentPlugin(
+                applicationContext,
+                ExperimentConfig(
+                    debug = true,
+                    fetchOnStart = false,
+                    pollOnStart = false,
+                ),
+            )
+
+        plugin.setup(analyticsClient, createContext())
+
+        Assert.assertNotNull(plugin.experimentClient)
+        Assert.assertNull(plugin.experimentClient?.getUser())
+    }
+
+    @Test
     fun `onIdentityChanged rebuilds user and triggers fetch`() {
         val plugin =
             AmplitudeExperimentPlugin(
@@ -89,13 +125,8 @@ class AmplitudeExperimentPluginTest {
                     pollOnStart = false,
                 ),
             )
-        val callbackSlot = slot<RemoteConfigClient.RemoteConfigCallback>()
-        every {
-            remoteConfigClient.subscribe(any(), any(), capture(callbackSlot))
-        } just Runs
 
         plugin.setup(analyticsClient, createContext())
-        callbackSlot.captured.onUpdate(null, RemoteConfigClient.Source.CACHE, 1L)
 
         val spyClient = spyk(plugin.experimentClient as DefaultExperimentClient)
         setExperimentClient(plugin, spyClient)
@@ -115,32 +146,6 @@ class AmplitudeExperimentPluginTest {
     }
 
     @Test
-    fun `onIdentityChanged waits for remote config before fetch`() {
-        val plugin =
-            AmplitudeExperimentPlugin(
-                applicationContext,
-                ExperimentConfig(
-                    debug = true,
-                    automaticFetchOnAmplitudeIdentityChange = true,
-                    fetchOnStart = false,
-                    pollOnStart = false,
-                ),
-            )
-        val callbackSlot = slot<RemoteConfigClient.RemoteConfigCallback>()
-        every {
-            remoteConfigClient.subscribe(any(), any(), capture(callbackSlot))
-        } just Runs
-
-        plugin.setup(analyticsClient, createContext())
-        val spyClient = spyk(plugin.experimentClient as DefaultExperimentClient)
-        setExperimentClient(plugin, spyClient)
-
-        plugin.onIdentityChanged(identity)
-
-        verify(exactly = 0) { spyClient.fetch(any()) }
-    }
-
-    @Test
     fun `onIdentityChanged does not fetch while opted out`() {
         val plugin =
             AmplitudeExperimentPlugin(
@@ -152,13 +157,8 @@ class AmplitudeExperimentPluginTest {
                     pollOnStart = false,
                 ),
             )
-        val callbackSlot = slot<RemoteConfigClient.RemoteConfigCallback>()
-        every {
-            remoteConfigClient.subscribe(any(), any(), capture(callbackSlot))
-        } just Runs
 
         plugin.setup(analyticsClient, createContext())
-        callbackSlot.captured.onUpdate(null, RemoteConfigClient.Source.CACHE, 1L)
         val spyClient = spyk(plugin.experimentClient as DefaultExperimentClient)
         setExperimentClient(plugin, spyClient)
 
@@ -179,13 +179,8 @@ class AmplitudeExperimentPluginTest {
                     pollOnStart = false,
                 ),
             )
-        val callbackSlot = slot<RemoteConfigClient.RemoteConfigCallback>()
-        every {
-            remoteConfigClient.subscribe(any(), any(), capture(callbackSlot))
-        } just Runs
 
         plugin.setup(analyticsClient, createContext())
-        callbackSlot.captured.onUpdate(null, RemoteConfigClient.Source.CACHE, 1L)
 
         plugin.onSessionIdChanged(99L)
 
@@ -194,7 +189,7 @@ class AmplitudeExperimentPluginTest {
     }
 
     @Test
-    fun `wait for remote delivery starts experiment client`() {
+    fun `onOptOutChanged resumes start after opting back in`() {
         val plugin =
             AmplitudeExperimentPlugin(
                 applicationContext,
@@ -204,74 +199,16 @@ class AmplitudeExperimentPluginTest {
                     pollOnStart = false,
                 ),
             )
-        val callbackSlot = slot<RemoteConfigClient.RemoteConfigCallback>()
-        every {
-            remoteConfigClient.subscribe(any(), any(), capture(callbackSlot))
-        } just Runs
 
         plugin.setup(analyticsClient, createContext())
-        Assert.assertNull(plugin.experimentClient?.getUser())
+        val spyClient = spyk(plugin.experimentClient as DefaultExperimentClient)
+        setExperimentClient(plugin, spyClient)
 
-        callbackSlot.captured.onUpdate(
-            mapOf("enabled" to true),
-            RemoteConfigClient.Source.REMOTE,
-            123L,
-        )
+        plugin.onOptOutChanged(true)
+        verify { spyClient.stop() }
 
-        Assert.assertNotNull(plugin.experimentClient?.getUser())
-        Assert.assertEquals("user-1", plugin.experimentClient?.getUser()?.userId)
-    }
-
-    @Test
-    fun `wait for remote timeout fallback still starts experiment client`() {
-        val plugin =
-            AmplitudeExperimentPlugin(
-                applicationContext,
-                ExperimentConfig(
-                    debug = true,
-                    fetchOnStart = false,
-                    pollOnStart = false,
-                ),
-            )
-        val callbackSlot = slot<RemoteConfigClient.RemoteConfigCallback>()
-        every {
-            remoteConfigClient.subscribe(any(), any(), capture(callbackSlot))
-        } just Runs
-
-        plugin.setup(analyticsClient, createContext())
-        Assert.assertNull(plugin.experimentClient?.getUser())
-
-        callbackSlot.captured.onUpdate(null, RemoteConfigClient.Source.REMOTE, null)
-
-        Assert.assertNotNull(plugin.experimentClient?.getUser())
-    }
-
-    @Test
-    fun `setup waits for experiment remote config with configured timeout`() {
-        val plugin =
-            AmplitudeExperimentPlugin(
-                context = applicationContext,
-                config =
-                    ExperimentConfig(
-                        debug = true,
-                        fetchOnStart = false,
-                        pollOnStart = false,
-                    ),
-                remoteConfigWaitTimeoutMs = 1_234L,
-            )
-
-        plugin.setup(analyticsClient, createContext())
-
-        verify {
-            remoteConfigClient.subscribe(
-                RemoteConfigClient.Key.Custom("experiment.androidSDK"),
-                match {
-                    it is RemoteConfigClient.DeliveryMode.WaitForRemote &&
-                        it.timeoutMs == 1_234L
-                },
-                any(),
-            )
-        }
+        plugin.onOptOutChanged(false)
+        verify { spyClient.start(any()) }
     }
 
     @Test
@@ -285,13 +222,8 @@ class AmplitudeExperimentPluginTest {
                     pollOnStart = false,
                 ),
             )
-        val callbackSlot = slot<RemoteConfigClient.RemoteConfigCallback>()
-        every {
-            remoteConfigClient.subscribe(any(), any(), capture(callbackSlot))
-        } just Runs
 
         plugin.setup(analyticsClient, createContext())
-        callbackSlot.captured.onUpdate(null, RemoteConfigClient.Source.CACHE, 1L)
 
         val spyClient = spyk(plugin.experimentClient as DefaultExperimentClient)
         setExperimentClient(plugin, spyClient)
@@ -300,6 +232,26 @@ class AmplitudeExperimentPluginTest {
 
         verify { spyClient.clear() }
         verify { spyClient.setUser(match { it.userId == "user-1" && it.deviceId == "device-1" }) }
+    }
+
+    @Test
+    fun `teardown stops and clears the experiment client`() {
+        val plugin =
+            AmplitudeExperimentPlugin(
+                applicationContext,
+                ExperimentConfig(
+                    debug = true,
+                    fetchOnStart = false,
+                    pollOnStart = false,
+                ),
+            )
+
+        plugin.setup(analyticsClient, createContext())
+        Assert.assertNotNull(plugin.experimentClient)
+
+        plugin.teardown()
+
+        Assert.assertNull(plugin.experimentClient)
     }
 
     @Test

--- a/sdk/src/test/java/com/amplitude/experiment/AmplitudeExperimentPluginTest.kt
+++ b/sdk/src/test/java/com/amplitude/experiment/AmplitudeExperimentPluginTest.kt
@@ -53,7 +53,7 @@ class AmplitudeExperimentPluginTest {
 
     @Test
     fun `exposure tracking routes through analytics client track`() {
-        val provider = AnalyticsClientExposureTrackingProvider(analyticsClient)
+        val provider = AnalyticsClientExposureTrackingProvider { analyticsClient }
         val exposure =
             Exposure(
                 flagKey = "flag-key",
@@ -112,6 +112,60 @@ class AmplitudeExperimentPluginTest {
         Assert.assertEquals("user-2", spyClient.getUser()?.userId)
         Assert.assertEquals("device-2", spyClient.getUser()?.deviceId)
         verify { spyClient.fetch(any()) }
+    }
+
+    @Test
+    fun `onIdentityChanged waits for remote config before fetch`() {
+        val plugin =
+            AmplitudeExperimentPlugin(
+                applicationContext,
+                ExperimentConfig(
+                    debug = true,
+                    automaticFetchOnAmplitudeIdentityChange = true,
+                    fetchOnStart = false,
+                    pollOnStart = false,
+                ),
+            )
+        val callbackSlot = slot<RemoteConfigClient.RemoteConfigCallback>()
+        every {
+            remoteConfigClient.subscribe(any(), any(), capture(callbackSlot))
+        } just Runs
+
+        plugin.setup(analyticsClient, createContext())
+        val spyClient = spyk(plugin.experimentClient as DefaultExperimentClient)
+        setExperimentClient(plugin, spyClient)
+
+        plugin.onIdentityChanged(identity)
+
+        verify(exactly = 0) { spyClient.fetch(any()) }
+    }
+
+    @Test
+    fun `onIdentityChanged does not fetch while opted out`() {
+        val plugin =
+            AmplitudeExperimentPlugin(
+                applicationContext,
+                ExperimentConfig(
+                    debug = true,
+                    automaticFetchOnAmplitudeIdentityChange = true,
+                    fetchOnStart = false,
+                    pollOnStart = false,
+                ),
+            )
+        val callbackSlot = slot<RemoteConfigClient.RemoteConfigCallback>()
+        every {
+            remoteConfigClient.subscribe(any(), any(), capture(callbackSlot))
+        } just Runs
+
+        plugin.setup(analyticsClient, createContext())
+        callbackSlot.captured.onUpdate(null, RemoteConfigClient.Source.CACHE, 1L)
+        val spyClient = spyk(plugin.experimentClient as DefaultExperimentClient)
+        setExperimentClient(plugin, spyClient)
+
+        plugin.onOptOutChanged(true)
+        plugin.onIdentityChanged(identity)
+
+        verify(exactly = 0) { spyClient.fetch(any()) }
     }
 
     @Test
@@ -193,6 +247,34 @@ class AmplitudeExperimentPluginTest {
     }
 
     @Test
+    fun `setup waits for experiment remote config with configured timeout`() {
+        val plugin =
+            AmplitudeExperimentPlugin(
+                context = applicationContext,
+                config =
+                    ExperimentConfig(
+                        debug = true,
+                        fetchOnStart = false,
+                        pollOnStart = false,
+                    ),
+                remoteConfigWaitTimeoutMs = 1_234L,
+            )
+
+        plugin.setup(analyticsClient, createContext())
+
+        verify {
+            remoteConfigClient.subscribe(
+                RemoteConfigClient.Key.Custom("experiment.androidSDK"),
+                match {
+                    it is RemoteConfigClient.DeliveryMode.WaitForRemote &&
+                        it.timeoutMs == 1_234L
+                },
+                any(),
+            )
+        }
+    }
+
+    @Test
     fun `onReset clears cached variants and rebuilds user`() {
         val plugin =
             AmplitudeExperimentPlugin(
@@ -224,6 +306,44 @@ class AmplitudeExperimentPluginTest {
     fun `plugin exposes stable name`() {
         val plugin = AmplitudeExperimentPlugin(applicationContext)
         Assert.assertEquals(AmplitudeExperimentPlugin.PLUGIN_NAME, plugin.name)
+    }
+
+    @Test
+    fun `plugin name includes deployment key`() {
+        val plugin =
+            AmplitudeExperimentPlugin(
+                context = applicationContext,
+                deploymentKey = "deployment-key",
+            )
+
+        Assert.assertEquals("${AmplitudeExperimentPlugin.PLUGIN_NAME}_deployment-key", plugin.name)
+    }
+
+    @Test
+    fun `plugin falls back to provided context when application context is unavailable`() {
+        val context = mockk<android.content.Context>()
+        every { context.applicationContext } returns null
+
+        val plugin = AmplitudeExperimentPlugin(context)
+
+        Assert.assertEquals(AmplitudeExperimentPlugin.PLUGIN_NAME, plugin.name)
+    }
+
+    @Test
+    fun `exposure tracking ignores disconnected analytics client`() {
+        var client: AnalyticsClient? = analyticsClient
+        val provider = AnalyticsClientExposureTrackingProvider { client }
+        client = null
+
+        provider.track(
+            Exposure(
+                flagKey = "flag-key",
+                variant = "treatment",
+                experimentKey = null,
+            ),
+        )
+
+        verify(exactly = 0) { analyticsClient.track(any(), any()) }
     }
 
     private fun createContext(): AmplitudeContext {

--- a/sdk/src/test/java/com/amplitude/experiment/AmplitudeExperimentPluginTest.kt
+++ b/sdk/src/test/java/com/amplitude/experiment/AmplitudeExperimentPluginTest.kt
@@ -1,5 +1,6 @@
 package com.amplitude.experiment
 
+import com.amplitude.analytics.connector.AnalyticsConnector
 import com.amplitude.common.Logger
 import com.amplitude.core.AmplitudeContext
 import com.amplitude.core.AnalyticsClient
@@ -49,6 +50,55 @@ class AmplitudeExperimentPluginTest {
     }
 
     @Test
+    fun `user provider falls back to connector user properties when identity map is empty`() {
+        val instanceName = "connector-props-instance"
+        val emptyIdentity =
+            object : AnalyticsIdentity {
+                override val userId: String? = "user-1"
+                override val deviceId: String? = "device-1"
+            }
+        every { analyticsClient.identity } returns emptyIdentity
+
+        AnalyticsConnector.getInstance(instanceName).identityStore
+            .editIdentity()
+            .setUserId("user-1")
+            .setDeviceId("device-1")
+            .setUserProperties(mapOf("plan" to "enterprise"))
+            .commit()
+
+        val provider =
+            AnalyticsClientUserProvider(
+                applicationContext,
+                { analyticsClient },
+                instanceName,
+            )
+
+        val user = provider.getUser()
+
+        Assert.assertEquals("enterprise", user.userProperties?.get("plan"))
+    }
+
+    @Test
+    fun `user provider prefers identity user properties over connector`() {
+        val instanceName = "identity-props-instance"
+        AnalyticsConnector.getInstance(instanceName).identityStore
+            .editIdentity()
+            .setUserProperties(mapOf("plan" to "connector"))
+            .commit()
+
+        val provider =
+            AnalyticsClientUserProvider(
+                applicationContext,
+                { analyticsClient },
+                instanceName,
+            )
+
+        val user = provider.getUser()
+
+        Assert.assertEquals("pro", user.userProperties?.get("plan"))
+    }
+
+    @Test
     fun `exposure tracking routes through analytics client track`() {
         val provider = AnalyticsClientExposureTrackingProvider { analyticsClient }
         val exposure =
@@ -72,6 +122,56 @@ class AmplitudeExperimentPluginTest {
                 ),
             )
         }
+    }
+
+    @Test
+    fun `automatic fetch registers connector identity listener for property updates`() {
+        val instanceName = "auto-fetch-instance"
+        val plugin =
+            AmplitudeExperimentPlugin(
+                applicationContext,
+                ExperimentConfig(
+                    debug = true,
+                    automaticFetchOnAmplitudeIdentityChange = true,
+                    fetchOnStart = false,
+                    pollOnStart = false,
+                ),
+            )
+
+        plugin.setup(analyticsClient, createContext(instanceName = instanceName))
+        val spyClient = spyk(plugin.experimentClient as DefaultExperimentClient)
+        setExperimentClient(plugin, spyClient)
+
+        AnalyticsConnector.getInstance(instanceName).identityStore
+            .editIdentity()
+            .setUserProperties(mapOf("plan" to "enterprise"))
+            .commit()
+
+        verify(timeout = 1_000) { spyClient.setUser(any()) }
+        verify(timeout = 1_000) { spyClient.fetch(any()) }
+    }
+
+    @Test
+    fun `teardown removes connector identity listener`() {
+        val instanceName = "teardown-listener-instance"
+        val plugin =
+            AmplitudeExperimentPlugin(
+                applicationContext,
+                ExperimentConfig(
+                    debug = true,
+                    automaticFetchOnAmplitudeIdentityChange = true,
+                    fetchOnStart = false,
+                    pollOnStart = false,
+                ),
+            )
+
+        plugin.setup(analyticsClient, createContext(instanceName = instanceName))
+        Assert.assertNotNull(getPrivateField(plugin, "connectorIdentityListener"))
+
+        plugin.teardown()
+
+        Assert.assertNull(plugin.experimentClient)
+        Assert.assertNull(getPrivateField(plugin, "connectorIdentityListener"))
     }
 
     @Test
@@ -212,7 +312,7 @@ class AmplitudeExperimentPluginTest {
     }
 
     @Test
-    fun `onReset clears cached variants and rebuilds user`() {
+    fun `onReset clears cached variants rebuilds user and fetches`() {
         val plugin =
             AmplitudeExperimentPlugin(
                 applicationContext,
@@ -232,6 +332,30 @@ class AmplitudeExperimentPluginTest {
 
         verify { spyClient.clear() }
         verify { spyClient.setUser(match { it.userId == "user-1" && it.deviceId == "device-1" }) }
+        verify { spyClient.fetch(any()) }
+    }
+
+    @Test
+    fun `onReset does not fetch while opted out`() {
+        val plugin =
+            AmplitudeExperimentPlugin(
+                applicationContext,
+                ExperimentConfig(
+                    debug = true,
+                    fetchOnStart = false,
+                    pollOnStart = false,
+                ),
+            )
+
+        plugin.setup(analyticsClient, createContext())
+        val spyClient = spyk(plugin.experimentClient as DefaultExperimentClient)
+        setExperimentClient(plugin, spyClient)
+
+        plugin.onOptOutChanged(true)
+        plugin.onReset()
+
+        verify { spyClient.clear() }
+        verify(exactly = 0) { spyClient.fetch(any()) }
     }
 
     @Test
@@ -298,10 +422,10 @@ class AmplitudeExperimentPluginTest {
         verify(exactly = 0) { analyticsClient.track(any(), any()) }
     }
 
-    private fun createContext(): AmplitudeContext {
+    private fun createContext(instanceName: String = ExperimentConfig.Defaults.INSTANCE_NAME): AmplitudeContext {
         return AmplitudeContext(
             apiKey = API_KEY,
-            instanceName = ExperimentConfig.Defaults.INSTANCE_NAME,
+            instanceName = instanceName,
             serverZone = CoreServerZone.US,
             logger = logger,
             remoteConfigClient = remoteConfigClient,
@@ -316,5 +440,14 @@ class AmplitudeExperimentPluginTest {
         val field = AmplitudeExperimentPlugin::class.java.getDeclaredField("experimentClient")
         field.isAccessible = true
         field.set(plugin, client)
+    }
+
+    private fun getPrivateField(
+        plugin: AmplitudeExperimentPlugin,
+        name: String,
+    ): Any? {
+        val field = AmplitudeExperimentPlugin::class.java.getDeclaredField(name)
+        field.isAccessible = true
+        return field.get(plugin)
     }
 }

--- a/sdk/src/test/java/com/amplitude/experiment/AmplitudeExperimentPluginTest.kt
+++ b/sdk/src/test/java/com/amplitude/experiment/AmplitudeExperimentPluginTest.kt
@@ -14,6 +14,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
+import io.mockk.verifyOrder
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -175,7 +176,7 @@ class AmplitudeExperimentPluginTest {
     }
 
     @Test
-    fun `setup starts experiment client without remote config`() {
+    fun `setup starts experiment client when host identity is ready`() {
         val plugin =
             AmplitudeExperimentPlugin(
                 applicationContext,
@@ -195,6 +196,75 @@ class AmplitudeExperimentPluginTest {
     }
 
     @Test
+    fun `setup does not start when host session is uninitialized`() {
+        every { analyticsClient.sessionId } returns -1L
+        val plugin =
+            AmplitudeExperimentPlugin(
+                applicationContext,
+                ExperimentConfig(
+                    debug = true,
+                    fetchOnStart = false,
+                    pollOnStart = false,
+                ),
+            )
+
+        plugin.setup(analyticsClient, createContext())
+
+        Assert.assertNotNull(plugin.experimentClient)
+        Assert.assertNull(plugin.experimentClient?.getUser())
+    }
+
+    @Test
+    fun `setup does not start when host device id is missing`() {
+        every { analyticsClient.identity } returns
+            object : AnalyticsIdentity {
+                override val userId: String? = "user-1"
+                override val deviceId: String? = null
+            }
+        val plugin =
+            AmplitudeExperimentPlugin(
+                applicationContext,
+                ExperimentConfig(
+                    debug = true,
+                    fetchOnStart = false,
+                    pollOnStart = false,
+                ),
+            )
+
+        plugin.setup(analyticsClient, createContext())
+
+        Assert.assertNotNull(plugin.experimentClient)
+        Assert.assertNull(plugin.experimentClient?.getUser())
+    }
+
+    @Test
+    fun `first start happens after identity and session become ready`() {
+        every { analyticsClient.sessionId } returns -1L
+        val plugin =
+            AmplitudeExperimentPlugin(
+                applicationContext,
+                ExperimentConfig(
+                    debug = true,
+                    fetchOnStart = false,
+                    pollOnStart = false,
+                ),
+            )
+
+        plugin.setup(analyticsClient, createContext())
+        Assert.assertNull(plugin.experimentClient?.getUser())
+
+        val spyClient = spyk(plugin.experimentClient as DefaultExperimentClient)
+        setExperimentClient(plugin, spyClient)
+        every { analyticsClient.sessionId } returns 42L
+
+        plugin.onSessionIdChanged(42L)
+
+        verify { spyClient.start(any()) }
+        Assert.assertEquals("user-1", spyClient.getUser()?.userId)
+        Assert.assertEquals("device-1", spyClient.getUser()?.deviceId)
+    }
+
+    @Test
     fun `setup does not start when opted out`() {
         every { analyticsClient.optOut } returns true
         val plugin =
@@ -211,6 +281,33 @@ class AmplitudeExperimentPluginTest {
 
         Assert.assertNotNull(plugin.experimentClient)
         Assert.assertNull(plugin.experimentClient?.getUser())
+    }
+
+    @Test
+    fun `onIdentityChanged does not fetch when automatic fetch is off`() {
+        val plugin =
+            AmplitudeExperimentPlugin(
+                applicationContext,
+                ExperimentConfig(
+                    debug = true,
+                    fetchOnStart = false,
+                    pollOnStart = false,
+                ),
+            )
+
+        plugin.setup(analyticsClient, createContext())
+        val spyClient = spyk(plugin.experimentClient as DefaultExperimentClient)
+        setExperimentClient(plugin, spyClient)
+
+        plugin.onIdentityChanged(
+            object : AnalyticsIdentity {
+                override val userId: String? = "user-2"
+                override val deviceId: String? = "device-2"
+            },
+        )
+
+        Assert.assertEquals("user-2", spyClient.getUser()?.userId)
+        verify(exactly = 0) { spyClient.fetch(any()) }
     }
 
     @Test
@@ -243,6 +340,33 @@ class AmplitudeExperimentPluginTest {
         Assert.assertEquals("user-2", spyClient.getUser()?.userId)
         Assert.assertEquals("device-2", spyClient.getUser()?.deviceId)
         verify { spyClient.fetch(any()) }
+    }
+
+    @Test
+    fun `connector identity listener does not fetch on user or device id change`() {
+        val instanceName = "no-double-fetch-instance"
+        val plugin =
+            AmplitudeExperimentPlugin(
+                applicationContext,
+                ExperimentConfig(
+                    debug = true,
+                    automaticFetchOnAmplitudeIdentityChange = true,
+                    fetchOnStart = false,
+                    pollOnStart = false,
+                ),
+            )
+
+        plugin.setup(analyticsClient, createContext(instanceName = instanceName))
+        val spyClient = spyk(plugin.experimentClient as DefaultExperimentClient)
+        setExperimentClient(plugin, spyClient)
+
+        AnalyticsConnector.getInstance(instanceName).identityStore
+            .editIdentity()
+            .setUserId("user-2")
+            .setDeviceId("device-2")
+            .commit()
+
+        verify(exactly = 0) { spyClient.fetch(any()) }
     }
 
     @Test
@@ -312,7 +436,7 @@ class AmplitudeExperimentPluginTest {
     }
 
     @Test
-    fun `onReset clears cached variants rebuilds user and fetches`() {
+    fun `onReset clears cached variants without fetch when automatic fetch is off`() {
         val plugin =
             AmplitudeExperimentPlugin(
                 applicationContext,
@@ -332,7 +456,34 @@ class AmplitudeExperimentPluginTest {
 
         verify { spyClient.clear() }
         verify { spyClient.setUser(match { it.userId == "user-1" && it.deviceId == "device-1" }) }
-        verify { spyClient.fetch(any()) }
+        verify(exactly = 0) { spyClient.fetch(any()) }
+    }
+
+    @Test
+    fun `onReset fetches after clear when automatic fetch is on`() {
+        val plugin =
+            AmplitudeExperimentPlugin(
+                applicationContext,
+                ExperimentConfig(
+                    debug = true,
+                    automaticFetchOnAmplitudeIdentityChange = true,
+                    fetchOnStart = false,
+                    pollOnStart = false,
+                ),
+            )
+
+        plugin.setup(analyticsClient, createContext())
+
+        val spyClient = spyk(plugin.experimentClient as DefaultExperimentClient)
+        setExperimentClient(plugin, spyClient)
+
+        plugin.onReset()
+
+        verifyOrder {
+            spyClient.clear()
+            spyClient.setUser(any())
+            spyClient.fetch(any())
+        }
     }
 
     @Test
@@ -376,12 +527,30 @@ class AmplitudeExperimentPluginTest {
         plugin.teardown()
 
         Assert.assertNull(plugin.experimentClient)
+
+        plugin.teardown()
+        Assert.assertNull(plugin.experimentClient)
     }
 
     @Test
     fun `plugin exposes stable name`() {
         val plugin = AmplitudeExperimentPlugin(applicationContext)
         Assert.assertEquals(AmplitudeExperimentPlugin.PLUGIN_NAME, plugin.name)
+    }
+
+    @Test
+    fun `execute is a pass-through`() {
+        val plugin = AmplitudeExperimentPlugin(applicationContext)
+        val event =
+            object : com.amplitude.core.events.AnalyticsEvent {
+                override var userId: String? = "u"
+                override var deviceId: String? = "d"
+                override var timestamp: Long? = 1L
+                override var sessionId: Long? = 2L
+                override var eventType: String = "test"
+                override var eventProperties: MutableMap<String, Any?>? = null
+            }
+        Assert.assertSame(event, plugin.execute(event))
     }
 
     @Test

--- a/sdk/src/test/java/com/amplitude/experiment/AmplitudeExperimentPluginTest.kt
+++ b/sdk/src/test/java/com/amplitude/experiment/AmplitudeExperimentPluginTest.kt
@@ -1,0 +1,248 @@
+package com.amplitude.experiment
+
+import com.amplitude.common.Logger
+import com.amplitude.core.AmplitudeContext
+import com.amplitude.core.AnalyticsClient
+import com.amplitude.core.AnalyticsIdentity
+import com.amplitude.core.RestrictedAmplitudeFeature
+import com.amplitude.core.diagnostics.DiagnosticsClient
+import com.amplitude.core.remoteconfig.RemoteConfigClient
+import com.amplitude.experiment.util.AmpLogger
+import com.amplitude.experiment.util.SystemLoggerProvider
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.spyk
+import io.mockk.verify
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import com.amplitude.core.ServerZone as CoreServerZone
+
+private const val API_KEY = "client-DvWljIjiiuqLbyjqdvBaLFfEBrAvGuA3"
+
+@OptIn(RestrictedAmplitudeFeature::class)
+class AmplitudeExperimentPluginTest {
+    init {
+        AmpLogger.loggerProvider = SystemLoggerProvider(true)
+    }
+
+    private val applicationContext = mockk<android.content.Context>(relaxed = true)
+    private val analyticsClient = mockk<AnalyticsClient>(relaxed = true)
+    private val remoteConfigClient = mockk<RemoteConfigClient>(relaxed = true)
+    private val logger = mockk<Logger>(relaxed = true)
+    private val diagnosticsClient = mockk<DiagnosticsClient>(relaxed = true)
+
+    private val identity =
+        object : AnalyticsIdentity {
+            override val userId: String? = "user-1"
+            override val deviceId: String? = "device-1"
+            override val userProperties: Map<String, Any?> = mapOf("plan" to "pro")
+        }
+
+    @Before
+    fun setUp() {
+        every { applicationContext.applicationContext } returns applicationContext
+        every { applicationContext.getSharedPreferences(any(), any()) } returns mockk(relaxed = true)
+        every { analyticsClient.identity } returns identity
+        every { analyticsClient.sessionId } returns 42L
+        every { analyticsClient.optOut } returns false
+    }
+
+    @Test
+    fun `exposure tracking routes through analytics client track`() {
+        val provider = AnalyticsClientExposureTrackingProvider(analyticsClient)
+        val exposure =
+            Exposure(
+                flagKey = "flag-key",
+                variant = "treatment",
+                experimentKey = "exp-key",
+                metadata = mapOf("source" to "remote"),
+            )
+
+        provider.track(exposure)
+
+        verify {
+            analyticsClient.track(
+                "\$exposure",
+                mapOf(
+                    "flag_key" to "flag-key",
+                    "variant" to "treatment",
+                    "experiment_key" to "exp-key",
+                    "metadata" to mapOf("source" to "remote"),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `onIdentityChanged rebuilds user and triggers fetch`() {
+        val plugin =
+            AmplitudeExperimentPlugin(
+                applicationContext,
+                ExperimentConfig(
+                    debug = true,
+                    automaticFetchOnAmplitudeIdentityChange = true,
+                    fetchOnStart = false,
+                    pollOnStart = false,
+                ),
+            )
+        val callbackSlot = slot<RemoteConfigClient.RemoteConfigCallback>()
+        every {
+            remoteConfigClient.subscribe(any(), any(), capture(callbackSlot))
+        } just Runs
+
+        plugin.setup(analyticsClient, createContext())
+        callbackSlot.captured.onUpdate(null, RemoteConfigClient.Source.CACHE, 1L)
+
+        val spyClient = spyk(plugin.experimentClient as DefaultExperimentClient)
+        setExperimentClient(plugin, spyClient)
+
+        val newIdentity =
+            object : AnalyticsIdentity {
+                override val userId: String? = "user-2"
+                override val deviceId: String? = "device-2"
+                override val userProperties: Map<String, Any?> = mapOf("plan" to "enterprise")
+            }
+
+        plugin.onIdentityChanged(newIdentity)
+
+        Assert.assertEquals("user-2", spyClient.getUser()?.userId)
+        Assert.assertEquals("device-2", spyClient.getUser()?.deviceId)
+        verify { spyClient.fetch(any()) }
+    }
+
+    @Test
+    fun `onSessionIdChanged updates session id on the user`() {
+        val plugin =
+            AmplitudeExperimentPlugin(
+                applicationContext,
+                ExperimentConfig(
+                    debug = true,
+                    fetchOnStart = false,
+                    pollOnStart = false,
+                ),
+            )
+        val callbackSlot = slot<RemoteConfigClient.RemoteConfigCallback>()
+        every {
+            remoteConfigClient.subscribe(any(), any(), capture(callbackSlot))
+        } just Runs
+
+        plugin.setup(analyticsClient, createContext())
+        callbackSlot.captured.onUpdate(null, RemoteConfigClient.Source.CACHE, 1L)
+
+        plugin.onSessionIdChanged(99L)
+
+        val user = plugin.experimentClient?.getUser()
+        Assert.assertEquals(99L, user?.userProperties?.get(AnalyticsClientUserProvider.SESSION_ID_USER_PROPERTY))
+    }
+
+    @Test
+    fun `wait for remote delivery starts experiment client`() {
+        val plugin =
+            AmplitudeExperimentPlugin(
+                applicationContext,
+                ExperimentConfig(
+                    debug = true,
+                    fetchOnStart = false,
+                    pollOnStart = false,
+                ),
+            )
+        val callbackSlot = slot<RemoteConfigClient.RemoteConfigCallback>()
+        every {
+            remoteConfigClient.subscribe(any(), any(), capture(callbackSlot))
+        } just Runs
+
+        plugin.setup(analyticsClient, createContext())
+        Assert.assertNull(plugin.experimentClient?.getUser())
+
+        callbackSlot.captured.onUpdate(
+            mapOf("enabled" to true),
+            RemoteConfigClient.Source.REMOTE,
+            123L,
+        )
+
+        Assert.assertNotNull(plugin.experimentClient?.getUser())
+        Assert.assertEquals("user-1", plugin.experimentClient?.getUser()?.userId)
+    }
+
+    @Test
+    fun `wait for remote timeout fallback still starts experiment client`() {
+        val plugin =
+            AmplitudeExperimentPlugin(
+                applicationContext,
+                ExperimentConfig(
+                    debug = true,
+                    fetchOnStart = false,
+                    pollOnStart = false,
+                ),
+            )
+        val callbackSlot = slot<RemoteConfigClient.RemoteConfigCallback>()
+        every {
+            remoteConfigClient.subscribe(any(), any(), capture(callbackSlot))
+        } just Runs
+
+        plugin.setup(analyticsClient, createContext())
+        Assert.assertNull(plugin.experimentClient?.getUser())
+
+        callbackSlot.captured.onUpdate(null, RemoteConfigClient.Source.REMOTE, null)
+
+        Assert.assertNotNull(plugin.experimentClient?.getUser())
+    }
+
+    @Test
+    fun `onReset clears cached variants and rebuilds user`() {
+        val plugin =
+            AmplitudeExperimentPlugin(
+                applicationContext,
+                ExperimentConfig(
+                    debug = true,
+                    fetchOnStart = false,
+                    pollOnStart = false,
+                ),
+            )
+        val callbackSlot = slot<RemoteConfigClient.RemoteConfigCallback>()
+        every {
+            remoteConfigClient.subscribe(any(), any(), capture(callbackSlot))
+        } just Runs
+
+        plugin.setup(analyticsClient, createContext())
+        callbackSlot.captured.onUpdate(null, RemoteConfigClient.Source.CACHE, 1L)
+
+        val spyClient = spyk(plugin.experimentClient as DefaultExperimentClient)
+        setExperimentClient(plugin, spyClient)
+
+        plugin.onReset()
+
+        verify { spyClient.clear() }
+        verify { spyClient.setUser(match { it.userId == "user-1" && it.deviceId == "device-1" }) }
+    }
+
+    @Test
+    fun `plugin exposes stable name`() {
+        val plugin = AmplitudeExperimentPlugin(applicationContext)
+        Assert.assertEquals(AmplitudeExperimentPlugin.PLUGIN_NAME, plugin.name)
+    }
+
+    private fun createContext(): AmplitudeContext {
+        return AmplitudeContext(
+            apiKey = API_KEY,
+            instanceName = ExperimentConfig.Defaults.INSTANCE_NAME,
+            serverZone = CoreServerZone.US,
+            logger = logger,
+            remoteConfigClient = remoteConfigClient,
+            diagnosticsClient = diagnosticsClient,
+        )
+    }
+
+    private fun setExperimentClient(
+        plugin: AmplitudeExperimentPlugin,
+        client: ExperimentClient,
+    ) {
+        val field = AmplitudeExperimentPlugin::class.java.getDeclaredField("experimentClient")
+        field.isAccessible = true
+        field.set(plugin, client)
+    }
+}

--- a/sdk/src/test/java/com/amplitude/experiment/AmplitudeExperimentPluginTest.kt
+++ b/sdk/src/test/java/com/amplitude/experiment/AmplitudeExperimentPluginTest.kt
@@ -153,6 +153,44 @@ class AmplitudeExperimentPluginTest {
     }
 
     @Test
+    fun `connector property update does not fetch before experiment starts`() {
+        val instanceName = "connector-before-start-instance"
+        every { analyticsClient.sessionId } returns -1L
+        every { analyticsClient.identity } returns
+            object : AnalyticsIdentity {
+                override val userId: String? = "user-1"
+                override val deviceId: String? = "device-1"
+            }
+        val plugin =
+            AmplitudeExperimentPlugin(
+                applicationContext,
+                ExperimentConfig(
+                    debug = true,
+                    automaticFetchOnAmplitudeIdentityChange = true,
+                    fetchOnStart = false,
+                    pollOnStart = false,
+                ),
+            )
+
+        plugin.setup(analyticsClient, createContext(instanceName = instanceName))
+        val spyClient = spyk(plugin.experimentClient as DefaultExperimentClient)
+        setExperimentClient(plugin, spyClient)
+
+        AnalyticsConnector.getInstance(instanceName).identityStore
+            .editIdentity()
+            .setUserProperties(mapOf("plan" to "enterprise"))
+            .commit()
+
+        verify(exactly = 0) { spyClient.fetch(any()) }
+
+        every { analyticsClient.sessionId } returns 42L
+        plugin.onSessionIdChanged(42L)
+
+        Assert.assertEquals("enterprise", spyClient.getUser()?.userProperties?.get("plan"))
+        verify { spyClient.start(any()) }
+    }
+
+    @Test
     fun `teardown removes connector identity listener`() {
         val instanceName = "teardown-listener-instance"
         val plugin =
@@ -530,6 +568,44 @@ class AmplitudeExperimentPluginTest {
 
         plugin.teardown()
         Assert.assertNull(plugin.experimentClient)
+    }
+
+    @Test
+    fun `plugins with the same instance own separate clients`() {
+        val context = createContext(instanceName = "separate-plugin-clients")
+        val firstPlugin =
+            AmplitudeExperimentPlugin(
+                applicationContext,
+                ExperimentConfig(
+                    debug = true,
+                    fetchOnStart = false,
+                    pollOnStart = false,
+                ),
+            )
+        val secondPlugin =
+            AmplitudeExperimentPlugin(
+                applicationContext,
+                ExperimentConfig(
+                    debug = true,
+                    fetchOnStart = false,
+                    pollOnStart = false,
+                ),
+            )
+
+        firstPlugin.setup(analyticsClient, context)
+        secondPlugin.setup(analyticsClient, context)
+
+        val firstClient = firstPlugin.experimentClient
+        val secondClient = secondPlugin.experimentClient
+        Assert.assertNotNull(firstClient)
+        Assert.assertNotNull(secondClient)
+        Assert.assertNotSame(firstClient, secondClient)
+
+        firstPlugin.teardown()
+
+        Assert.assertNull(firstPlugin.experimentClient)
+        Assert.assertSame(secondClient, secondPlugin.experimentClient)
+        Assert.assertEquals("user-1", secondPlugin.experimentClient?.getUser()?.userId)
     }
 
     @Test

--- a/sdk/src/test/java/com/amplitude/experiment/ExperimentClientTest.kt
+++ b/sdk/src/test/java/com/amplitude/experiment/ExperimentClientTest.kt
@@ -24,6 +24,7 @@ import org.junit.Before
 import org.junit.Test
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutionException
+import java.util.concurrent.ScheduledThreadPoolExecutor
 
 private const val API_KEY = "client-DvWljIjiiuqLbyjqdvBaLFfEBrAvGuA3"
 private const val SERVER_API_KEY = "server-qz35UwzJ5akieoAdIgzM4m9MIiOLXLoz"
@@ -49,6 +50,10 @@ fun assertVariantEquals(
 }
 
 class ExperimentClientTest {
+    companion object {
+        private val executorService = ScheduledThreadPoolExecutor(4)
+    }
+
     init {
         AmpLogger.loggerProvider = SystemLoggerProvider(true)
     }
@@ -83,7 +88,7 @@ class ExperimentClientTest {
             ),
             OkHttpClient(),
             mockStorage,
-            Experiment.executorService,
+            executorService,
         )
 
     private val timeoutClient =
@@ -97,7 +102,7 @@ class ExperimentClientTest {
             ),
             OkHttpClient(),
             mockStorage,
-            Experiment.executorService,
+            executorService,
         )
 
     private val initialVariantSourceClient =
@@ -110,7 +115,7 @@ class ExperimentClientTest {
             ),
             OkHttpClient(),
             mockStorage,
-            Experiment.executorService,
+            executorService,
         )
 
     private val generalClient =
@@ -121,7 +126,7 @@ class ExperimentClientTest {
             ),
             OkHttpClient(),
             mockStorage,
-            Experiment.executorService,
+            executorService,
         )
 
     @Before
@@ -302,7 +307,7 @@ class ExperimentClientTest {
                 ),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         analyticsProviderClient.fetch(testUser).get()
         analyticsProviderClient.variant(KEY)
@@ -347,7 +352,7 @@ class ExperimentClientTest {
                 ),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         analyticsProviderClient.fetch(testUser).get()
         analyticsProviderClient.variant("asdf")
@@ -391,7 +396,7 @@ class ExperimentClientTest {
                 ),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         analyticsProviderClient.fetch(testUser).get()
         analyticsProviderClient.variant(INITIAL_KEY)
@@ -433,7 +438,7 @@ class ExperimentClientTest {
                 ),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         analyticsProviderClient.fetch(testUser).get()
         analyticsProviderClient.variant(KEY)
@@ -471,7 +476,7 @@ class ExperimentClientTest {
                 ),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         client.variant("flagKey")
         Assert.assertTrue(didTrack)
@@ -485,7 +490,7 @@ class ExperimentClientTest {
                 ExperimentConfig(),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         Assert.assertEquals("https://api.lab.amplitude.com/".toHttpUrl(), client.serverUrl)
         Assert.assertEquals("https://flag.lab.amplitude.com/".toHttpUrl(), client.flagsServerUrl)
@@ -499,7 +504,7 @@ class ExperimentClientTest {
                 ExperimentConfig(serverZone = ServerZone.US),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         Assert.assertEquals("https://api.lab.amplitude.com/".toHttpUrl(), client.serverUrl)
         Assert.assertEquals("https://flag.lab.amplitude.com/".toHttpUrl(), client.flagsServerUrl)
@@ -517,7 +522,7 @@ class ExperimentClientTest {
                 ),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         Assert.assertEquals("https://experiment.company.com".toHttpUrl(), client.serverUrl)
         Assert.assertEquals("https://flags.company.com".toHttpUrl(), client.flagsServerUrl)
@@ -531,7 +536,7 @@ class ExperimentClientTest {
                 ExperimentConfig(serverZone = ServerZone.EU),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         Assert.assertEquals("https://api.lab.eu.amplitude.com/".toHttpUrl(), client.serverUrl)
         Assert.assertEquals("https://flag.lab.eu.amplitude.com/".toHttpUrl(), client.flagsServerUrl)
@@ -549,7 +554,7 @@ class ExperimentClientTest {
                 ),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         Assert.assertEquals("https://experiment.company.com".toHttpUrl(), client.serverUrl)
         Assert.assertEquals("https://flags.company.com".toHttpUrl(), client.flagsServerUrl)
@@ -563,7 +568,7 @@ class ExperimentClientTest {
                 ExperimentConfig(fetchOnStart = true),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         client.start(ExperimentUser(deviceId = "test_device")).get()
         Assert.assertEquals("sdk-ci-test-local", client.allFlags()["sdk-ci-test-local"]?.key)
@@ -578,7 +583,7 @@ class ExperimentClientTest {
                 ExperimentConfig(fetchOnStart = true),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         client.start(ExperimentUser(deviceId = "test_device")).get()
         var variant = client.variant("sdk-ci-test-local")
@@ -599,7 +604,7 @@ class ExperimentClientTest {
                 ExperimentConfig(fetchOnStart = false),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         val user = ExperimentUser(userId = "test_user", deviceId = "test_device")
         client.start(user).get()
@@ -629,7 +634,7 @@ class ExperimentClientTest {
                 ),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         client.start(user).get()
         val variant = client.variant("sdk-ci-test")
@@ -662,7 +667,7 @@ class ExperimentClientTest {
                 ),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         client.start(user).get()
         val variant = client.variant("sdk-ci-test", inlineVariant)
@@ -693,7 +698,7 @@ class ExperimentClientTest {
                 ),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         client.start(user).get()
         val variant = client.variant("sdk-ci-test")
@@ -724,7 +729,7 @@ class ExperimentClientTest {
                 ),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         client.start(user).get()
         val variant = client.variant("sdk-ci-test")
@@ -754,7 +759,7 @@ class ExperimentClientTest {
                 ),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         client.start(user).get()
         val variant = client.variant("sdk-ci-test")
@@ -787,7 +792,7 @@ class ExperimentClientTest {
                 ),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         client.start(user).get()
         val variant = client.variant("sdk-ci-test")
@@ -818,7 +823,7 @@ class ExperimentClientTest {
                 ),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         client.start(user).get()
         val variant = client.variant("sdk-ci-test", inlineVariant)
@@ -851,7 +856,7 @@ class ExperimentClientTest {
                 ),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         client.start(user).get()
         val variant = client.variant("sdk-ci-test", inlineVariant)
@@ -882,7 +887,7 @@ class ExperimentClientTest {
                 ),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         client.start(user).get()
         val variant = client.variant("sdk-ci-test")
@@ -912,7 +917,7 @@ class ExperimentClientTest {
                 ),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         client.start(user).get()
         val variant = client.variant("sdk-ci-test")
@@ -943,7 +948,7 @@ class ExperimentClientTest {
                 ),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         client.start(user).get()
         val variant = client.variant("sdk-ci-test-local", inlineVariant)
@@ -976,7 +981,7 @@ class ExperimentClientTest {
                 ),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         client.start(user).get()
         val variant = client.variant("sdk-ci-test-local", inlineVariant)
@@ -1007,7 +1012,7 @@ class ExperimentClientTest {
                 ),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         client.start(user).get()
         val variant = client.variant("sdk-ci-test-local")
@@ -1038,7 +1043,7 @@ class ExperimentClientTest {
                 ),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         client.start(user).get()
         val variant = client.variant("sdk-ci-test-local")
@@ -1067,7 +1072,7 @@ class ExperimentClientTest {
                 ),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         client.start(user).get()
         val variant = client.variant("sdk-ci-test-local")
@@ -1101,7 +1106,7 @@ class ExperimentClientTest {
                 ),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         client.start(user).get()
         val allVariants = client.all()
@@ -1133,7 +1138,7 @@ class ExperimentClientTest {
                 ),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         client.start(user).get()
         val allVariants = client.all()
@@ -1154,7 +1159,7 @@ class ExperimentClientTest {
                 ExperimentConfig(),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         val spyClient = spyk(client)
         spyClient.start(null).get()
@@ -1169,7 +1174,7 @@ class ExperimentClientTest {
                 ExperimentConfig(),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         val spyClient = spyk(client)
         every { spyClient.allFlags() } returns emptyMap()
@@ -1185,7 +1190,7 @@ class ExperimentClientTest {
                 ExperimentConfig(fetchOnStart = true),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         val spyClient = spyk(client)
         every { spyClient.allFlags() } returns emptyMap()
@@ -1201,7 +1206,7 @@ class ExperimentClientTest {
                 ExperimentConfig(fetchOnStart = false),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         val spyClient = spyk(client)
         spyClient.start(null).get()
@@ -1224,7 +1229,7 @@ class ExperimentClientTest {
                 ),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         client.start(user).get()
         var variant = client.variant("sdk-payload-ci-test")
@@ -1259,7 +1264,7 @@ class ExperimentClientTest {
                 ),
                 OkHttpClient(),
                 storage,
-                Experiment.executorService,
+                executorService,
             )
         val user = ExperimentUser(userId = "user_id", deviceId = "device_id")
         client.setUser(user)
@@ -1282,7 +1287,7 @@ class ExperimentClientTest {
                 ),
                 OkHttpClient(),
                 storage,
-                Experiment.executorService,
+                executorService,
             )
         // Storage flag should take precedent over initial flag
         variant = client.variant("sdk-ci-test-local")
@@ -1312,7 +1317,7 @@ class ExperimentClientTest {
                         ExperimentConfig(retryFetchOnFailure = true),
                         OkHttpClient(),
                         storage,
-                        Experiment.executorService,
+                        executorService,
                     ),
                     recordPrivateCalls = true,
                 )
@@ -1356,7 +1361,7 @@ class ExperimentClientTest {
                 ExperimentConfig(),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         Assert.assertEquals(300000, client.flagConfigPollingIntervalMillis)
     }
@@ -1371,7 +1376,7 @@ class ExperimentClientTest {
                 ),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         Assert.assertEquals(60000, client.flagConfigPollingIntervalMillis)
     }
@@ -1386,7 +1391,7 @@ class ExperimentClientTest {
                 ),
                 OkHttpClient(),
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         Assert.assertEquals(900000, client.flagConfigPollingIntervalMillis)
     }
@@ -1400,7 +1405,7 @@ class ExperimentClientTest {
                 ExperimentConfig(),
                 OkHttpClient(),
                 storage,
-                Experiment.executorService,
+                executorService,
             )
 
         // Test that setTracksAssignment returns the client for chaining
@@ -1423,7 +1428,7 @@ class ExperimentClientTest {
                 ExperimentConfig(),
                 OkHttpClient(),
                 storage,
-                Experiment.executorService,
+                executorService,
             )
 
         // Create second client with same storage
@@ -1433,7 +1438,7 @@ class ExperimentClientTest {
                 ExperimentConfig(),
                 OkHttpClient(),
                 storage,
-                Experiment.executorService,
+                executorService,
             )
 
         // Set track assignment event on first client
@@ -1454,7 +1459,7 @@ class ExperimentClientTest {
                 ExperimentConfig(),
                 OkHttpClient(),
                 storage,
-                Experiment.executorService,
+                executorService,
             )
 
         // Set track assignment event to true, then false
@@ -1476,7 +1481,7 @@ class ExperimentClientTest {
                 ExperimentConfig(),
                 OkHttpClient(),
                 storage,
-                Experiment.executorService,
+                executorService,
             )
 
         // Set track assignment event to true
@@ -1514,7 +1519,7 @@ class ExperimentClientTest {
                 ),
                 mockHttpClient,
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
 
         try {
@@ -1562,7 +1567,7 @@ class ExperimentClientTest {
                 ),
                 mockHttpClient,
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
 
         try {
@@ -1604,7 +1609,7 @@ class ExperimentClientTest {
                 ),
                 mockHttpClient,
                 mockStorage,
-                Experiment.executorService,
+                executorService,
             )
         return client to mockHttpClient
     }
@@ -1662,7 +1667,7 @@ class ExperimentClientTest {
                 ),
                 OkHttpClient(),
                 MockStorage(),
-                Experiment.executorService,
+                executorService,
             )
 
         client.setUser(ExperimentUser(userId = "user-a"))
@@ -1698,7 +1703,7 @@ class ExperimentClientTest {
                 ),
                 OkHttpClient(),
                 MockStorage(),
-                Experiment.executorService,
+                executorService,
             )
 
         client.setUser(ExperimentUser(deviceId = "device-a"))
@@ -1725,7 +1730,7 @@ class ExperimentClientTest {
                 ),
                 OkHttpClient(),
                 MockStorage(),
-                Experiment.executorService,
+                executorService,
             )
 
         client.setUser(ExperimentUser(userId = "user-a"))
@@ -1748,7 +1753,7 @@ class ExperimentClientTest {
                 ),
                 OkHttpClient(),
                 MockStorage(),
-                Experiment.executorService,
+                executorService,
             )
 
         client.setUser(ExperimentUser(userId = "user-a", deviceId = "device-a"))
@@ -1775,7 +1780,7 @@ class ExperimentClientTest {
                 ),
                 OkHttpClient(),
                 MockStorage(),
-                Experiment.executorService,
+                executorService,
             )
 
         // anonymous user — device id only, no user id yet


### PR DESCRIPTION
## Summary
- Add `AmplitudeExperimentPlugin` on `UniversalPlugin` (analytics-core 1.30.1) so Experiment can register via `amplitude.add(plugin)`.
- Bridge exposure tracking and user identity through `AnalyticsClient`; start in `setup` (no remote-config gate), matching iOS/Web Experiment plugins.
- Keep the shared `OkHttpClient` and executor private. The plugin and `Experiment.initialize*` construct clients through internal `Experiment.createClient`, so they share one connection pool without exposing OkHttp on the `Experiment` API.

## Test plan
- [x] `./gradlew :sdk:ktlintCheck :sdk:test`
- [x] Smoke: register plugin on unified Amplitude client, confirm start/fetch and `$exposure` via analytics